### PR TITLE
Fix spelling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@
 //! * `distance_compiletime`  the fastest instruction set availble for the given compile time
 //! feature set
 //!
-//! You may also forgoe the macros if you know what you are doing, just keep in mind there are lots
+//! You may also forgo the macros if you know what you are doing, just keep in mind there are lots
 //! of arcane subtleties with inlining and target_features that must be managed. See how the macros
 //! expand for more detail.
 #![cfg_attr(


### PR DESCRIPTION
I think the correct spelling is forgo or forego, correct me if I'm wrong.