### PR TITLE
fix: 'this URL is not a hyperlink' error

### DIFF
--- a/src/libm/mod.rs
+++ b/src/libm/mod.rs
@@ -1,6 +1,6 @@
 //! libm in pure Rust
 //!
-//! This is pulled from  https://github.com/rust-lang-nursery/libm
+//! This is pulled from <https://github.com/rust-lang-nursery/libm>
 //! Maintainers of that project have gone dark, and I had to fix some things
 //! so I just pulled it into simdeez.
 //! This is all just to support no_std


### PR DESCRIPTION
When running `cargo doc`, an error is raised.
This is resolved by following the compiler hint message:
```
error: this URL is not a hyperlink
 --> src/libm/mod.rs:3:26
  |
3 | //! This is pulled from  https://github.com/rust-lang-nursery/libm
  |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://github.com/rust-lang-nursery/libm>`
  |
  = note: bare URLs are not automatically turned into clickable links
note: the lint level is defined here
 --> src/libm/mod.rs:8:9
  |
8 | #![deny(warnings)]
  |         ^^^^^^^^
  = note: `#[deny(rustdoc::bare_urls)]` implied by `#[deny(warnings)]`
```