### PR TITLE
Verpeteren/slli epi64

### DIFF
--- a/src/avx/avx.rs
+++ b/src/avx/avx.rs
@@ -826,4 +826,13 @@ mod test {
             assert_eq!(got.i64_4, [987648, 987648, 987648, 987648]);
         }
     }
+
+    #[test]
+    fn test_avx_ops_shl() {
+        unsafe {
+            let lanes = Avx::set1_epi64(123456);
+            let got = Converter { simd: lanes << 3 };
+            assert_eq!(got.i64_4, [987648, 987648, 987648, 987648]);
+        }
+    }
 }

--- a/src/avx/avx.rs
+++ b/src/avx/avx.rs
@@ -806,3 +806,24 @@ impl Simd for Avx {
         }
     }
 }
+
+#[cfg(all(test, target_feature = "avx"))]
+mod test {
+    use super::*;
+
+    union Converter {
+        simd: I64x4,
+        i64_4: [i64; 4],
+    }
+
+    #[test]
+    fn test_avx_slli_epi64() {
+        unsafe {
+            let lanes = Avx::set1_epi64(123456);
+            let converter = Converter { simd: Avx::slli_epi64(lanes, 0) };
+            assert_eq!(converter.i64_4, [123456, 123456, 123456, 123456]);
+            let got = Converter { simd: Sse2::slli_epi64(lanes, 3) };
+            assert_eq!(got.i64_4, [987648, 987648, 987648, 987648]);
+        }
+    }
+}

--- a/src/avx/overloads.rs
+++ b/src/avx/overloads.rs
@@ -504,6 +504,16 @@ impl Shl<i32> for I32x8 {
     }
 }
 
+impl Shl<i32> for I64x4 {
+    type Output = I64x4;
+
+    #[inline(always)]
+    fn shl(self, rhs: i32) -> I64x4 {
+        unsafe { m256i_run_on_halves_1_simd!(Shl::shl, self, rhs, I64x2_41, Self) }
+    }
+}
+
+
 impl ShrAssign<i32> for I16x16 {
     #[inline(always)]
     fn shr_assign(&mut self, rhs: i32) {

--- a/src/avx2/avx2.rs
+++ b/src/avx2/avx2.rs
@@ -537,6 +537,15 @@ impl Simd for Avx2 {
         constify_imm8!(amt_const, call)
     }
     #[inline(always)]
+    unsafe fn slli_epi64(a: Self::Vi64, amt_const: i32) -> Self::Vi64 {
+        macro_rules! call {
+            ($amt_const:expr) => {
+                I64x4(_mm256_slli_epi64(a.0, $amt_const))
+            };
+        }
+        constify_imm8!(amt_const, call)
+    }
+    #[inline(always)]
     unsafe fn sra_epi32(a: Self::Vi32, amt: i32) -> Self::Vi32 {
         I32x8(_mm256_sra_epi32(a.0, _mm_set1_epi32(amt)))
     }

--- a/src/avx2/avx2.rs
+++ b/src/avx2/avx2.rs
@@ -810,4 +810,13 @@ mod test {
             assert_eq!(got.i64_4, [987648, 987648, 987648, 987648]);
         }
     }
+
+    #[test]
+    fn test_avx2_ops_shl() {
+        unsafe {
+            let lanes = Avx2::set1_epi64(123456);
+            let got = Converter { simd: lanes << 3 };
+            assert_eq!(got.i64_4, [987648, 987648, 987648, 987648]);
+        }
+    }
 }

--- a/src/avx2/avx2.rs
+++ b/src/avx2/avx2.rs
@@ -790,3 +790,24 @@ impl Simd for Avx2 {
         }
     }
 }
+
+#[cfg(all(test, target_feature = "avx2"))]
+mod test {
+    use super::*;
+
+    union Converter {
+        simd: I64x4,
+        i64_4: [i64; 4],
+    }
+
+    #[test]
+    fn test_avx2_slli_epi64() {
+        unsafe {
+            let lanes = Avx2::set1_epi64(123456);
+            let converter = Converter { simd: Avx2::slli_epi64(lanes, 0) };
+            assert_eq!(converter.i64_4, [123456, 123456, 123456, 123456]);
+            let got = Converter { simd: Avx2::slli_epi64(lanes, 3) };
+            assert_eq!(got.i64_4, [987648, 987648, 987648, 987648]);
+        }
+    }
+}

--- a/src/avx2/overloads.rs
+++ b/src/avx2/overloads.rs
@@ -516,6 +516,20 @@ impl Shl<i32> for I32x8 {
     }
 }
 
+impl Shl<i32> for I64x4 {
+    type Output = I64x4;
+
+    #[inline(always)]
+    fn shl(self, rhs: i32) -> I64x4 {
+        macro_rules! call {
+            ($rhs:expr) => {
+                unsafe { I64x4(_mm256_slli_epi64(self.0, $rhs)) }
+            };
+        }
+        constify_imm8!(rhs, call)
+    }
+}
+
 impl ShrAssign<i32> for I16x16 {
     #[inline(always)]
     fn shr_assign(&mut self, rhs: i32) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,6 +560,8 @@ pub trait Simd: Sync + Send {
     unsafe fn srai_epi64(a: Self::Vi64, amt_const: i32) -> Self::Vi64;
     /// amt must be a constant
     unsafe fn srli_epi32(a: Self::Vi32, amt_const: i32) -> Self::Vi32;
+    /// amt must be a constant
+    unsafe fn slli_epi64(a: Self::Vi64, amt_const: i32) -> Self::Vi64;
 
     /// amt does not have to be a constant, but may be slower than the srai version
     unsafe fn sra_epi32(a: Self::Vi32, amt: i32) -> Self::Vi32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,6 +311,11 @@ pub trait Simd: Sync + Send {
     }
     /// amt must be a constant
     #[inline(always)]
+    unsafe fn slli_epi64(a: Self::Vi64, amt_const: i32) -> Self::Vi64 {
+        a << amt_const
+    }
+    /// amt must be a constant
+    #[inline(always)]
     unsafe fn srai_epi32(a: Self::Vi32, amt_const: i32) -> Self::Vi32 {
         a >> amt_const
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,11 +309,20 @@ pub trait Simd: Sync + Send {
     unsafe fn slli_epi32(a: Self::Vi32, amt_const: i32) -> Self::Vi32 {
         a << amt_const
     }
+    /*
+    TODO: Fix this compile error
+    expected Simd::Vi64, found core::ops::Shl::Output
+    |
+    = note: expected associated type `<Self as Simd>::Vi64`
+               found associated type `<<Self as Simd>::Vi64 as core::ops::Shl<i32>>::Output`
+
     /// amt must be a constant
     #[inline(always)]
-    unsafe fn slli_epi64(a: Self::Vi64, amt_const: i32) -> Self::Vi64 {
+    unsafe fn slli_epi64(a: Self::Vi64, amt_const: i32) -> Self::Vi64 
+        where <Self as Simd>::Vi64: core::ops::Shl<i32> {
         a << amt_const
     }
+    */
     /// amt must be a constant
     #[inline(always)]
     unsafe fn srai_epi32(a: Self::Vi32, amt_const: i32) -> Self::Vi32 {

--- a/src/scalar/scalar.rs
+++ b/src/scalar/scalar.rs
@@ -628,6 +628,13 @@ impl Simd for Scalar {
         ))
     }
     #[inline(always)]
+    unsafe fn slli_epi64(a: Self::Vi64, amt_const: i32) -> Self::Vi64 {
+        //Transmute to unsigned so we don't get sign bits in the shift
+        I64x1(mem::transmute::<u64, i64>(
+            mem::transmute::<i64, u64>(a.0) << amt_const,
+        ))
+    }
+    #[inline(always)]
     unsafe fn sra_epi32(a: Self::Vi32, amt: i32) -> Self::Vi32 {
         a >> amt
     }

--- a/src/scalar/scalar.rs
+++ b/src/scalar/scalar.rs
@@ -815,4 +815,13 @@ mod test {
             assert_eq!(got.i64_1, [987648]);
         }
     }
+
+    #[test]
+    fn test_scalar_ops_shl () {
+        unsafe {
+            let lanes = Scalar::set1_epi64(123456);
+            let got = Converter { simd: lanes << 3 };
+            assert_eq!(got.i64_1, [987648]);
+        }
+    }
 }

--- a/src/scalar/scalar.rs
+++ b/src/scalar/scalar.rs
@@ -795,3 +795,24 @@ impl Simd for Scalar {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    union Converter {
+        simd: I64x1,
+        i64_1: [i64; 1],
+    }
+
+    #[test]
+    fn test_scalar_slli_epi64() {
+        unsafe {
+            let lanes = Scalar::set1_epi64(123456);
+            let converter = Converter { simd: Scalar::slli_epi64(lanes, 0) };
+            assert_eq!(converter.i64_1, [123456]);
+            let got = Converter { simd: Scalar::slli_epi64(lanes, 3) };
+            assert_eq!(got.i64_1, [987648]);
+        }
+    }
+}

--- a/src/sse2/overloads.rs
+++ b/src/sse2/overloads.rs
@@ -531,6 +531,7 @@ impl Shl<i32> for I16x8 {
         constify_imm8!(rhs, call)
     }
 }
+
 impl Shl<i32> for I32x4 {
     type Output = I32x4;
 
@@ -539,6 +540,20 @@ impl Shl<i32> for I32x4 {
         macro_rules! call {
             ($rhs:expr) => {
                 unsafe { I32x4(_mm_slli_epi32(self.0, $rhs)) }
+            };
+        }
+        constify_imm8!(rhs, call)
+    }
+}
+
+impl Shl<i32> for I64x2 {
+    type Output = I64x2;
+
+    #[inline(always)]
+    fn shl(self, rhs: i32) -> I64x2 {
+        macro_rules! call {
+            ($rhs:expr) => {
+                unsafe { I64x2(_mm_slli_epi64(self.0, $rhs)) }
             };
         }
         constify_imm8!(rhs, call)

--- a/src/sse2/sse2.rs
+++ b/src/sse2/sse2.rs
@@ -849,3 +849,24 @@ impl Simd for Sse2 {
         }
     }
 }
+
+#[cfg(all(test, target_feature = "sse2"))]
+mod test {
+    use super::*;
+
+    union Converter {
+        simd: I64x2,
+        i64_2: [i64; 2],
+    }
+
+    #[test]
+    fn test_sse2_slli_epi64() {
+        unsafe {
+            let lanes = Sse2::set1_epi64(123456);
+            let converter = Converter { simd: Sse2::slli_epi64(lanes, 0) };
+            assert_eq!(converter.i64_2, [123456, 123456]);
+            let got = Converter { simd: Sse2::slli_epi64(lanes, 3) };
+            assert_eq!(got.i64_2, [987648, 987648]);
+        }
+    }
+}

--- a/src/sse2/sse2.rs
+++ b/src/sse2/sse2.rs
@@ -676,6 +676,15 @@ impl Simd for Sse2 {
         constify_imm8!(amt_const, call)
     }
     #[inline(always)]
+    unsafe fn slli_epi64(a: Self::Vi64, amt_const: i32) -> Self::Vi64 {
+        macro_rules! call {
+            ($amt_const:expr) => {
+                I64x2(_mm_slli_epi64(a.0, $amt_const))
+            };
+        }
+        constify_imm8!(amt_const, call)
+    }
+    #[inline(always)]
     unsafe fn sra_epi32(a: Self::Vi32, amt: i32) -> Self::Vi32 {
         I32x4(_mm_sra_epi32(a.0, _mm_set1_epi32(amt)))
     }

--- a/src/sse2/sse2.rs
+++ b/src/sse2/sse2.rs
@@ -869,4 +869,13 @@ mod test {
             assert_eq!(got.i64_2, [987648, 987648]);
         }
     }
+
+    #[test]
+    fn test_sse2_ops_shl() {
+        unsafe {
+            let lanes = Sse2::set1_epi64(123456);
+            let got = Converter { simd: lanes << 3 };
+            assert_eq!(got.i64_2, [987648, 987648]);
+        }
+    }
 }

--- a/src/sse41/overloads.rs
+++ b/src/sse41/overloads.rs
@@ -176,6 +176,7 @@ impl ShlAssign<i32> for I32x4_41 {
         constify_imm8!(rhs, call)
     }
 }
+
 impl Shl<i32> for I32x4_41 {
     type Output = I32x4_41;
 
@@ -184,6 +185,20 @@ impl Shl<i32> for I32x4_41 {
         macro_rules! call {
             ($rhs:expr) => {
                 unsafe { I32x4_41(_mm_slli_epi32(self.0, $rhs)) }
+            };
+        }
+        constify_imm8!(rhs, call)
+    }
+}
+
+impl Shl<i32> for I64x2_41 {
+    type Output = I64x2_41;
+
+    #[inline(always)]
+    fn shl(self, rhs: i32) -> I64x2_41 {
+        macro_rules! call {
+            ($rhs:expr) => {
+                unsafe { I64x2_41(_mm_slli_epi64(self.0, $rhs)) }
             };
         }
         constify_imm8!(rhs, call)

--- a/src/sse41/sse41.rs
+++ b/src/sse41/sse41.rs
@@ -803,4 +803,13 @@ mod test {
             assert_eq!(got.i64_2, [987648, 987648]);
         }
     }
+
+    #[test]
+    fn test_sse41_ops_shl() {
+        unsafe {
+            let lanes = Sse41::set1_epi64(123456);
+            let got = Converter { simd: lanes << 3 };
+            assert_eq!(got.i64_2, [987648, 987648]);
+        }
+    }
 }

--- a/src/sse41/sse41.rs
+++ b/src/sse41/sse41.rs
@@ -606,6 +606,15 @@ impl Simd for Sse41 {
         constify_imm8!(amt_const, call)
     }
     #[inline(always)]
+    unsafe fn slli_epi64(a: Self::Vi64, amt_const: i32) -> Self::Vi64 {
+        macro_rules! call {
+            ($amt_const:expr) => {
+                I64x2_41(_mm_slli_epi64(a.0, $amt_const))
+            };
+        }
+        constify_imm8!(amt_const, call)
+    }
+    #[inline(always)]
     unsafe fn sra_epi32(a: Self::Vi32, amt: i32) -> Self::Vi32 {
         I32x4_41(_mm_sra_epi32(a.0, _mm_set1_epi32(amt)))
     }

--- a/src/sse41/sse41.rs
+++ b/src/sse41/sse41.rs
@@ -783,3 +783,24 @@ impl Simd for Sse41 {
         }
     }
 }
+
+#[cfg(all(test, target_feature = "sse4.1"))]
+mod test {
+    use super::*;
+
+    union Converter {
+        simd: I64x2_41,
+        i64_2: [i64; 2],
+    }
+
+    #[test]
+    fn test_sse41_slli_epi64() {
+        unsafe {
+            let lanes = Sse41::set1_epi64(123456);
+            let converter = Converter { simd: Sse41::slli_epi64(lanes, 0) };
+            assert_eq!(converter.i64_2, [123456, 123456]);
+            let got = Converter { simd: Sse41::slli_epi64(lanes, 3) };
+            assert_eq!(got.i64_2, [987648, 987648]);
+        }
+    }
+}

--- a/src/wasm32/overloads.rs
+++ b/src/wasm32/overloads.rs
@@ -514,6 +514,7 @@ impl Shl<i32> for I16x8 {
         constify_imm8!(rhs, call)
     }
 }
+
 impl Shl<i32> for I32x4 {
     type Output = I32x4;
 
@@ -522,6 +523,20 @@ impl Shl<i32> for I32x4 {
         macro_rules! call {
             ($rhs:expr) => {
                 unsafe { I32x4(_mm_slli_epi32(self.0, $rhs)) }
+            };
+        }
+        constify_imm8!(rhs, call)
+    }
+}
+
+impl Shl<i32> for I64x2 {
+    type Output = I64x2;
+
+    #[inline(always)]
+    fn shl(self, rhs: i32) -> I64x2 {
+        macro_rules! call {
+            ($rhs:expr) => {
+                unsafe { I64x2(_mm_slli_epi64(self.0, $rhs)) }
             };
         }
         constify_imm8!(rhs, call)

--- a/src/wasm32/wasm32.rs
+++ b/src/wasm32/wasm32.rs
@@ -811,3 +811,23 @@ impl Simd for Sse2 {
     }
 }
 
+#[cfg(all(test, target_feature = "sse2"))]
+mod test {
+    use super::*;
+
+    union Converter {
+        simd: I64x2,
+        i64_2: [i64; 2],
+    }
+
+    #[test]
+    fn test_wasm_slli_epi64() {
+        unsafe {
+            let lanes = Sse2::set1_epi64(123456);
+            let converter = Converter { simd: Sse2::slli_epi64(lanes, 0) };
+            assert_eq!(converter.i64_2, [123456, 123456]);
+            let got = Converter { simd: Sse2::slli_epi64(lanes, 3) };
+            assert_eq!(got.i64_2, [987648, 987648]);
+        }
+    }
+}

--- a/src/wasm32/wasm32.rs
+++ b/src/wasm32/wasm32.rs
@@ -830,4 +830,14 @@ mod test {
             assert_eq!(got.i64_2, [987648, 987648]);
         }
     }
+
+    #[test]
+    #[ignore]
+    fn test_wasm_ops_shl () {
+        unsafe {
+            let lanes = Sse2::set1_epi64(123456);
+            let got = Converter { simd: lanes << 3 };
+            assert_eq!(got.i64_2, [987648, 987648]);
+        }
+    }
 }

--- a/src/wasm32/wasm32.rs
+++ b/src/wasm32/wasm32.rs
@@ -634,6 +634,17 @@ impl Simd for Sse2 {
         }
         constify_imm8!(amt_const, call)
     }
+
+    #[inline(always)]
+    unsafe fn slli_epi64(a: Self::Vi64, amt_const: i32) -> Self::Vi64 {
+        macro_rules! call {
+            ($amt_const:expr) => {
+                I64x2(_mm_slli_epi64(a.0, $amt_const))
+            };
+        }
+        constify_imm8!(amt_const, call)
+    }
+
     #[inline(always)]
     unsafe fn sra_epi32(a: Self::Vi32, amt: i32) -> Self::Vi32 {
         I32x4(_mm_sra_epi32(a.0, _mm_set1_epi32(amt)))
@@ -799,3 +810,4 @@ impl Simd for Sse2 {
         }
     }
 }
+


### PR DESCRIPTION
This PR adds [slli_epi64](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=slli_epi64&ig_expand=6737,6740) functions as requested in [this issue](https://github.com/jackmott/simdeez/issues/41)

Known issues:
- I did not run the unittests for avx and avx2, I need to fiddle with `RUSTFLAGS=-C target-features=+axv, +avx2`
- I did not finish the wasmer implementation, that file seems to be a placeholder, based on a old version of sse2
- I could not activate the default implementation to the `Simd` trait due to a compile error that I could not resolve (yet).