### PR TITLE
improve test consistency

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -126,10 +126,20 @@ mod tests {
         sample::<Scalar>()
     }
     #[test]
-    fn consistency() {
+    fn consistency_sse2_sse41() {
         unsafe {
             assert_eq!(sample_sse2(), sample_sse41());            
+        }
+    }
+    #[test]
+    fn consistency_sse2_avx2() {
+        unsafe {
             assert_eq!(sample_sse2(), sample_avx2());
+        }
+    }
+    #[test]
+    fn consistency_scalar_avx2() {
+        unsafe {
             assert_eq!(sample_scalar(), sample_avx2());
         }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -125,22 +125,34 @@ mod tests {
     unsafe fn sample_scalar() -> i32 {
         sample::<Scalar>()
     }
+
+    #[cfg(target_arch = "x86_64")]
     #[test]
     fn consistency_sse2_sse41() {
-        unsafe {
-            assert_eq!(sample_sse2(), sample_sse41());            
+        if is_x86_feature_detected!("sse2") && is_x86_feature_detected!("sse4.1") {
+            unsafe {
+                assert_eq!(sample_sse2(), sample_sse41());            
+            }
         }
     }
+
+    #[cfg(target_arch = "x86_64")]
     #[test]
     fn consistency_sse2_avx2() {
-        unsafe {
-            assert_eq!(sample_sse2(), sample_avx2());
+        if is_x86_feature_detected!("sse2") && is_x86_feature_detected!("avx2") {
+            unsafe {
+                assert_eq!(sample_sse2(), sample_avx2());
+            }
         }
     }
+
+    #[cfg(target_arch = "x86_64")]
     #[test]
     fn consistency_scalar_avx2() {
-        unsafe {
-            assert_eq!(sample_scalar(), sample_avx2());
+        if is_x86_feature_detected!("avx2") {
+            unsafe {
+                assert_eq!(sample_scalar(), sample_avx2());
+            }
         }
     }
 }


### PR DESCRIPTION
This PR splits the consistency tests into 3 separate test functions that are gated by `target_arch` and `target_feature`.
It should address [this issue](https://github.com/arduano/simdeez/issues/10)