### PR TITLE
Support for Arm Neon intrinsics

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [build]
 # rustflags = "-C target-cpu=native"
-# rustflags = "-C target-feature=-sse4.1,-avx,-sse3"
+rustflags = "-C target-feature=-sse4.1,-avx,-sse3"
 target = "aarch64-unknown-linux-gnu"
 
 [target.aarch64-unknown-linux-gnu]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,9 @@
 [build]
 # rustflags = "-C target-cpu=native"
-rustflags = "-C target-feature=-sse4.1,-avx,-sse3"
 # target = "aarch64-unknown-linux-gnu"
+
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))']
+rustflags = "-C target-feature=-sse4.1,-avx,-sse3"
 
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,6 @@ target = "aarch64-unknown-linux-gnu"
 
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
+
+[registries.crates-io]
+protocol = "sparse"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [build]
 # rustflags = "-C target-cpu=native"
 rustflags = "-C target-feature=-sse4.1,-avx,-sse3"
-target = "aarch64-unknown-linux-gnu"
+# target = "aarch64-unknown-linux-gnu"
 
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
 [build]
-rustflags = "-C target-cpu=native"
+# rustflags = "-C target-cpu=native"
 # rustflags = "-C target-feature=-sse4.1,-avx,-sse3"
+target = "aarch64-unknown-linux-gnu"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,8 +3,42 @@ on: [pull_request]
 name: Lints
 
 jobs:
-  tests:
-    name: Tests
+  checks:
+    name: Code Checks (formatting, clippy)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        name: Initialize Cargo
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        name: Cargo Cache
+
+      - uses: actions-rs/cargo@v1
+        name: Check code formatting
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - uses: actions-rs/cargo@v1
+        name: Clippy check (x86)
+        with:
+          command: clippy
+          args: --all --all-targets -- --deny "warnings"
+
+      - uses: actions-rs/cargo@v1
+        name: Clippy check (arm64)
+        with:
+          command: clippy
+          args: --all --all-targets --target aarch64-unknown-linux-gnu -- --deny "warnings"
+
+  x86_tests:
+    name: x86 Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,11 +51,13 @@ jobs:
       QEMU_LD_PREFIX: /usr/aarch64-linux-gnu
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions-rs/toolchain@v1
         name: Initialize Cargo
         with:
           profile: minimal
           toolchain: stable
+          target: aarch64-unknown-linux-gnu
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,6 +52,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install dependencies
+        run: sudo apt-get install -y gcc-aarch64-linux-gnu qemu-user
+
       - uses: actions-rs/toolchain@v1
         name: Initialize Cargo
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,10 +9,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
-        name: Initialize Cargo
+        name: Initialize Cargo x86
         with:
           profile: minimal
           toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - uses: actions-rs/toolchain@v1
+        name: Initialize Cargo aarch64
+        with:
+          profile: minimal
+          toolchain: stable
+          target: aarch64-unknown-linux-gnu
           override: true
           components: rustfmt, clippy
 
@@ -52,18 +61,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         name: Cargo Cache
-
-      - uses: actions-rs/cargo@v1
-        name: Check code formatting
-        with:
-          command: fmt
-          args: --all -- --check
-
-      - uses: actions-rs/cargo@v1
-        name: Check code with clippy
-        with:
-          command: clippy
-          args: --all -- --deny "warnings"
 
       # Ensure that everything happens safely (with runtime checks)
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -72,14 +72,6 @@ jobs:
         with:
           platforms: aarch64
 
-      # Ensure that everything happens safely (with runtime checks)
-      - uses: actions-rs/cargo@v1
-        name: Run tests (debug)
-        with:
-          command: test
-          args: --target aarch64-unknown-linux-gnu
-
-      # Ensure that no behavior gets optimized out
       - uses: actions-rs/cargo@v1
         name: Run tests (release)
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,3 +43,40 @@ jobs:
         with:
           command: test
           args: --release
+
+  arm_tests:
+    name: Arm Neon Tests
+    runs-on: ubuntu-latest
+    env:
+      QEMU_LD_PREFIX: /usr/aarch64-linux-gnu
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        name: Initialize Cargo
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        name: Cargo Cache
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: aarch64
+
+      # Ensure that everything happens safely (with runtime checks)
+      - uses: actions-rs/cargo@v1
+        name: Run tests (debug)
+        with:
+          command: test
+          args: --target aarch64-unknown-linux-gnu
+
+      # Ensure that no behavior gets optimized out
+      - uses: actions-rs/cargo@v1
+        name: Run tests (release)
+        with:
+          command: test
+          args: --release --target aarch64-unknown-linux-gnu

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
     "--all",
     "--message-format=json",
     "--all-targets",
+    "--target=aarch64-unknown-linux-gnu",
     "--no-default-features"
     // "--features",
     // "no_std",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "--all",
     "--message-format=json",
     "--all-targets",
-    "--target=aarch64-unknown-linux-gnu",
+    // "--target=aarch64-unknown-linux-gnu",
     "--no-default-features"
     // "--features",
     // "no_std",

--- a/__ARM_TEST_CLI
+++ b/__ARM_TEST_CLI
@@ -1,0 +1,1 @@
+QEMU_LD_PREFIX=/usr/aarch64-linux-gnu cargo test --target aarch64-unknown-linux-gnu

--- a/benches/numparse.rs
+++ b/benches/numparse.rs
@@ -15,6 +15,8 @@ impl<'a> NumberParser<'a> {
     }
 
     fn get_next(&mut self) -> Option<u64> {
+        #![allow(clippy::manual_is_ascii_check)]
+
         let is_num_byte = |b: u8| (b'0'..=b'9').contains(&b);
 
         if self.string.is_empty() {

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -36,6 +36,8 @@ impl<'a> NumberParser<'a> {
     }
 
     fn get_next(&mut self) -> Option<u64> {
+        #![allow(clippy::manual_is_ascii_check)]
+
         let is_num_byte = |b: u8| (b'0'..=b'9').contains(&b);
 
         if self.string.is_empty() {

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -1,4 +1,11 @@
-pub mod avx2;
 pub mod scalar;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub mod avx2;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod sse2;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod sse41;
+
+#[cfg(target_arch = "aarch64")]
+pub mod neon;

--- a/src/engines/neon/mod.rs
+++ b/src/engines/neon/mod.rs
@@ -13,26 +13,26 @@ use crate::ops::*;
 mod simd;
 pub use self::simd::*;
 
-define_simd_type!(i8, 16, int8x16_t, _N);
-impl_simd_int_overloads!(I8x16_N);
-impl_i8_simd_type!(Neon, I8x16_N, I16x8_N);
+define_simd_type!(i8, 16, int8x16_t, Neon);
+impl_simd_int_overloads!(I8x16Neon);
+impl_i8_simd_type!(Neon, I8x16Neon, I16x8Neon);
 
-define_simd_type!(i16, 8, int16x8_t, _N);
-impl_simd_int_overloads!(I16x8_N);
-impl_i16_simd_type!(Neon, I16x8_N, I32x4_N);
+define_simd_type!(i16, 8, int16x8_t, Neon);
+impl_simd_int_overloads!(I16x8Neon);
+impl_i16_simd_type!(Neon, I16x8Neon, I32x4Neon);
 
-define_simd_type!(i32, 4, int32x4_t, _N);
-impl_simd_int_overloads!(I32x4_N);
-impl_i32_simd_type!(Neon, I32x4_N, F32x4_N, I64x2_N);
+define_simd_type!(i32, 4, int32x4_t, Neon);
+impl_simd_int_overloads!(I32x4Neon);
+impl_i32_simd_type!(Neon, I32x4Neon, F32x4Neon, I64x2Neon);
 
-define_simd_type!(i64, 2, int64x2_t, _N);
-impl_simd_int_overloads!(I64x2_N);
-impl_i64_simd_type!(Neon, I64x2_N, F64x2_N);
+define_simd_type!(i64, 2, int64x2_t, Neon);
+impl_simd_int_overloads!(I64x2Neon);
+impl_i64_simd_type!(Neon, I64x2Neon, F64x2Neon);
 
-define_simd_type!(f32, 4, float32x4_t, _N);
-impl_simd_float_overloads!(F32x4_N);
-impl_f32_simd_type!(Neon, F32x4_N, I32x4_N);
+define_simd_type!(f32, 4, float32x4_t, Neon);
+impl_simd_float_overloads!(F32x4Neon);
+impl_f32_simd_type!(Neon, F32x4Neon, I32x4Neon);
 
-define_simd_type!(f64, 2, float64x2_t, _N);
-impl_simd_float_overloads!(F64x2_N);
-impl_f64_simd_type!(Neon, F64x2_N, I64x2_N);
+define_simd_type!(f64, 2, float64x2_t, Neon);
+impl_simd_float_overloads!(F64x2Neon);
+impl_f64_simd_type!(Neon, F64x2Neon, I64x2Neon);

--- a/src/engines/neon/mod.rs
+++ b/src/engines/neon/mod.rs
@@ -1,0 +1,38 @@
+#[cfg(target_arch = "aarch64")]
+use core::arch::aarch64::*;
+
+use core::ops::*;
+
+use crate::{
+    InternalSimdBaseIo, SimdBaseOps, SimdConsts, SimdFloat, SimdFloat32, SimdFloat64, SimdInt,
+    SimdInt16, SimdInt32, SimdInt64, SimdInt8,
+};
+
+use crate::ops::*;
+
+mod simd;
+pub use self::simd::*;
+
+define_simd_type!(i8, 16, int8x16_t, _N);
+impl_simd_int_overloads!(I8x16_N);
+impl_i8_simd_type!(Neon, I8x16_N, I16x8_N);
+
+define_simd_type!(i16, 8, int16x8_t, _N);
+impl_simd_int_overloads!(I16x8_N);
+impl_i16_simd_type!(Neon, I16x8_N, I32x4_N);
+
+define_simd_type!(i32, 4, int32x4_t, _N);
+impl_simd_int_overloads!(I32x4_N);
+impl_i32_simd_type!(Neon, I32x4_N, F32x4_N, I64x2_N);
+
+define_simd_type!(i64, 2, int64x2_t, _N);
+impl_simd_int_overloads!(I64x2_N);
+impl_i64_simd_type!(Neon, I64x2_N, F64x2_N);
+
+define_simd_type!(f32, 4, float32x4_t, _N);
+impl_simd_float_overloads!(F32x4_N);
+impl_f32_simd_type!(Neon, F32x4_N, I32x4_N);
+
+define_simd_type!(f64, 2, float64x2_t, _N);
+impl_simd_float_overloads!(F64x2_N);
+impl_f64_simd_type!(Neon, F64x2_N, I64x2_N);

--- a/src/engines/neon/simd.rs
+++ b/src/engines/neon/simd.rs
@@ -1,0 +1,23 @@
+use super::*;
+use crate::Simd;
+
+pub struct Neon;
+impl Simd for Neon {
+    type Vi8 = I8x16_N;
+    type Vi16 = I16x8_N;
+    type Vi32 = I32x4_N;
+    type Vf32 = F32x4_N;
+    type Vf64 = F64x2_N;
+    type Vi64 = I64x2_N;
+
+    #[inline]
+    fn invoke<R>(f: impl FnOnce() -> R) -> R {
+        #[inline]
+        #[target_feature(enable = "neon")]
+        unsafe fn inner<R>(f: impl FnOnce() -> R) -> R {
+            f()
+        }
+
+        unsafe { inner(f) }
+    }
+}

--- a/src/engines/neon/simd.rs
+++ b/src/engines/neon/simd.rs
@@ -3,12 +3,12 @@ use crate::Simd;
 
 pub struct Neon;
 impl Simd for Neon {
-    type Vi8 = I8x16_N;
-    type Vi16 = I16x8_N;
-    type Vi32 = I32x4_N;
-    type Vf32 = F32x4_N;
-    type Vf64 = F64x2_N;
-    type Vi64 = I64x2_N;
+    type Vi8 = I8x16Neon;
+    type Vi16 = I16x8Neon;
+    type Vi32 = I32x4Neon;
+    type Vf32 = F32x4Neon;
+    type Vf64 = F64x2Neon;
+    type Vi64 = I64x2Neon;
 
     #[inline]
     fn invoke<R>(f: impl FnOnce() -> R) -> R {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,14 +538,14 @@ pub trait Simd: 'static + Sync + Send {
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn castps_pd(a: Self::Vf32) -> Self::Vf64 {
+    unsafe fn castps_pd(_a: Self::Vf32) -> Self::Vf64 {
         panic!("Deprecated")
     }
     /// Converts the type of a f64 vector to a f32 vector without changing the underlying bits.
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn castpd_ps(a: Self::Vf64) -> Self::Vf32 {
+    unsafe fn castpd_ps(_a: Self::Vf64) -> Self::Vf32 {
         panic!("Deprecated")
     }
 
@@ -872,13 +872,13 @@ pub trait Simd: 'static + Sync + Send {
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn i32gather_epi32(arr: &[i32], index: Self::Vi32) -> Self::Vi32 {
+    unsafe fn i32gather_epi32(_arr: &[i32], _index: Self::Vi32) -> Self::Vi32 {
         panic!("Deprecated")
     }
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn i64gather_epi64(arr: &[i64], index: Self::Vi64) -> Self::Vi64 {
+    unsafe fn i64gather_epi64(_arr: &[i64], _index: Self::Vi64) -> Self::Vi64 {
         panic!("Deprecated")
     }
     /// Sse2 and Sse41 paths will simulate a gather by breaking out and
@@ -886,7 +886,7 @@ pub trait Simd: 'static + Sync + Send {
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn i32gather_ps(arr: &[f32], index: Self::Vi32) -> Self::Vf32 {
+    unsafe fn i32gather_ps(_arr: &[f32], _index: Self::Vi32) -> Self::Vf32 {
         panic!("Deprecated")
     }
 
@@ -951,7 +951,7 @@ pub trait Simd: 'static + Sync + Send {
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn maskload_epi32(mem_addr: &i32, mask: Self::Vi32) -> Self::Vi32 {
+    unsafe fn maskload_epi32(_mem_addr: &i32, _mask: Self::Vi32) -> Self::Vi32 {
         panic!("Deprecated")
     }
     /// Note, SSE2 and SSE4 will load when mask[i] is nonzero, where AVX2
@@ -960,7 +960,7 @@ pub trait Simd: 'static + Sync + Send {
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn maskload_epi64(mem_addr: &i64, mask: Self::Vi64) -> Self::Vi64 {
+    unsafe fn maskload_epi64(_mem_addr: &i64, _mask: Self::Vi64) -> Self::Vi64 {
         panic!("Deprecated")
     }
     /// Note, SSE2 and SSE4 will load when mask[i] is nonzero, where AVX2
@@ -969,7 +969,7 @@ pub trait Simd: 'static + Sync + Send {
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn maskload_ps(mem_addr: &f32, mask: Self::Vi32) -> Self::Vf32 {
+    unsafe fn maskload_ps(_mem_addr: &f32, _mask: Self::Vi32) -> Self::Vf32 {
         panic!("Deprecated")
     }
     /// Note, SSE2 and SSE4 will load when mask[i] is nonzero, where AVX2
@@ -978,7 +978,7 @@ pub trait Simd: 'static + Sync + Send {
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn maskload_pd(mem_addr: &f64, mask: Self::Vi64) -> Self::Vf64 {
+    unsafe fn maskload_pd(_mem_addr: &f64, _mask: Self::Vi64) -> Self::Vf64 {
         panic!("Deprecated")
     }
 
@@ -1280,7 +1280,7 @@ pub trait Simd: 'static + Sync + Send {
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn shuffle_epi32(a: Self::Vi32, imm8: i32) -> Self::Vi32 {
+    unsafe fn shuffle_epi32(_a: Self::Vi32, _imm8: i32) -> Self::Vi32 {
         panic!("Deprecated")
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,8 @@ mod ops;
 pub mod prelude;
 
 use core::ops::*;
+
+#[cfg(target_arch = "aarch64")]
 use std::arch::is_aarch64_feature_detected;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,7 @@ mod ops;
 pub mod prelude;
 
 use core::ops::*;
+use std::arch::is_aarch64_feature_detected;
 
 #[macro_use]
 mod macros;
@@ -534,9 +535,19 @@ pub trait Simd: 'static + Sync + Send {
     }
 
     /// Converts the type of a f32 vector to a f64 vector without changing the underlying bits.
-    unsafe fn castps_pd(a: Self::Vf32) -> Self::Vf64;
+    #[deprecated(
+        note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
+    )]
+    unsafe fn castps_pd(a: Self::Vf32) -> Self::Vf64 {
+        panic!("Deprecated")
+    }
     /// Converts the type of a f64 vector to a f32 vector without changing the underlying bits.
-    unsafe fn castpd_ps(a: Self::Vf64) -> Self::Vf32;
+    #[deprecated(
+        note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
+    )]
+    unsafe fn castpd_ps(a: Self::Vf64) -> Self::Vf32 {
+        panic!("Deprecated")
+    }
 
     /// Currently scalar will have different results in some cases depending on the
     /// current SSE rounding mode.
@@ -861,17 +872,23 @@ pub trait Simd: 'static + Sync + Send {
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn i32gather_epi32(arr: &[i32], index: Self::Vi32) -> Self::Vi32;
+    unsafe fn i32gather_epi32(arr: &[i32], index: Self::Vi32) -> Self::Vi32 {
+        panic!("Deprecated")
+    }
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn i64gather_epi64(arr: &[i64], index: Self::Vi64) -> Self::Vi64;
+    unsafe fn i64gather_epi64(arr: &[i64], index: Self::Vi64) -> Self::Vi64 {
+        panic!("Deprecated")
+    }
     /// Sse2 and Sse41 paths will simulate a gather by breaking out and
     /// doing scalar array accesses, because gather doesn't exist until Avx2.
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn i32gather_ps(arr: &[f32], index: Self::Vi32) -> Self::Vf32;
+    unsafe fn i32gather_ps(arr: &[f32], index: Self::Vi32) -> Self::Vf32 {
+        panic!("Deprecated")
+    }
 
     #[deprecated(
         note = "Functions on the Simd trait are deprecated, please use the functions on the Vf32, Vf64, Vi16, Vi32, and Vi64 types instead."
@@ -934,28 +951,36 @@ pub trait Simd: 'static + Sync + Send {
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn maskload_epi32(mem_addr: &i32, mask: Self::Vi32) -> Self::Vi32;
+    unsafe fn maskload_epi32(mem_addr: &i32, mask: Self::Vi32) -> Self::Vi32 {
+        panic!("Deprecated")
+    }
     /// Note, SSE2 and SSE4 will load when mask[i] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability
     /// ensure that the high bit is set.
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn maskload_epi64(mem_addr: &i64, mask: Self::Vi64) -> Self::Vi64;
+    unsafe fn maskload_epi64(mem_addr: &i64, mask: Self::Vi64) -> Self::Vi64 {
+        panic!("Deprecated")
+    }
     /// Note, SSE2 and SSE4 will load when mask[i] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability
     /// ensure that the high bit is set.
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn maskload_ps(mem_addr: &f32, mask: Self::Vi32) -> Self::Vf32;
+    unsafe fn maskload_ps(mem_addr: &f32, mask: Self::Vi32) -> Self::Vf32 {
+        panic!("Deprecated")
+    }
     /// Note, SSE2 and SSE4 will load when mask[i] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability
     /// ensure that the high bit is set.
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn maskload_pd(mem_addr: &f64, mask: Self::Vi64) -> Self::Vf64;
+    unsafe fn maskload_pd(mem_addr: &f64, mask: Self::Vi64) -> Self::Vf64 {
+        panic!("Deprecated")
+    }
 
     #[deprecated(
         note = "Functions on the Simd trait are deprecated, please use the functions on the Vf32, Vf64, Vi16, Vi32, and Vi64 types instead."
@@ -1255,7 +1280,9 @@ pub trait Simd: 'static + Sync + Send {
     #[deprecated(
         note = "These functions have unpredictable behavior and will be deleted in the future. Please use a manual implementation instead."
     )]
-    unsafe fn shuffle_epi32(a: Self::Vi32, imm8: i32) -> Self::Vi32;
+    unsafe fn shuffle_epi32(a: Self::Vi32, imm8: i32) -> Self::Vi32 {
+        panic!("Deprecated")
+    }
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "sleef")] {
@@ -1323,9 +1350,10 @@ macro_rules! simd_runtime_generate {
             }
 
             #[target_feature(enable = "sse4.1")]
-                $vis unsafe fn [<$fn_name _sse41>]($($arg:$typ,)*) $(-> $rt)? {
+            $vis unsafe fn [<$fn_name _sse41>]($($arg:$typ,)*) $(-> $rt)? {
                 $fn_name::<Sse41>($($arg,)*)
             }
+
             #[target_feature(enable = "avx2")]
             $vis  unsafe fn [<$fn_name _avx2>]($($arg:$typ,)*) $(-> $rt)? {
                 $fn_name::<Avx2>($($arg,)*)
@@ -1403,15 +1431,27 @@ pub trait SimdRunner<A, R> {
 
 #[inline(always)]
 pub fn run_simd_runtime_decide<S: SimdRunner<A, R>, A, R>(args: A) -> R {
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     if is_x86_feature_detected!("avx2") {
-        unsafe { S::run::<engines::avx2::Avx2>(args) }
-    } else if is_x86_feature_detected!("sse4.1") {
-        unsafe { S::run::<engines::sse41::Sse41>(args) }
-    } else if is_x86_feature_detected!("sse2") {
-        unsafe { S::run::<engines::sse2::Sse2>(args) }
-    } else {
-        unsafe { S::run::<engines::scalar::Scalar>(args) }
+        return unsafe { S::run::<engines::avx2::Avx2>(args) };
     }
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    if is_x86_feature_detected!("sse4.1") {
+        return unsafe { S::run::<engines::sse41::Sse41>(args) };
+    }
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    if is_x86_feature_detected!("sse2") {
+        return unsafe { S::run::<engines::sse2::Sse2>(args) };
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    if is_aarch64_feature_detected!("neon") {
+        return unsafe { S::run::<engines::neon::Neon>(args) };
+    }
+
+    unsafe { S::run::<engines::scalar::Scalar>(args) }
 }
 
 #[inline(always)]

--- a/src/ops/bit.rs
+++ b/src/ops/bit.rs
@@ -14,6 +14,9 @@ impl_op! {
         for Scalar(a: u64, b: u64) -> u64 {
             a & b
         }
+        for Neon(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            vandq_s8(a, b)
+        }
     }
 }
 
@@ -31,6 +34,9 @@ impl_op! {
         for Scalar(a: u64, b: u64) -> u64 {
             a | b
         }
+        for Neon(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            vorrq_s8(a, b)
+        }
     }
 }
 
@@ -47,6 +53,9 @@ impl_op! {
         }
         for Scalar(a: u64, b: u64) -> u64 {
             a ^ b
+        }
+        for Neon(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            veorq_s8(a, b)
         }
     }
 }
@@ -68,6 +77,9 @@ impl_op! {
         for Scalar(a: u64) -> u64 {
             !a
         }
+        for Neon(a: int8x16_t) -> int8x16_t {
+            vreinterpretq_s8_u8(vmvnq_u8(vreinterpretq_u8_s8(a)))
+        }
     }
 }
 
@@ -84,6 +96,9 @@ impl_op! {
         }
         for Scalar(a: u64, b: u64) -> u64 {
             !a & b
+        }
+        for Neon(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            vandq_s8(vreinterpretq_s8_u8(vmvnq_u8(vreinterpretq_u8_s8(a))), b)
         }
     }
 }

--- a/src/ops/casts.rs
+++ b/src/ops/casts.rs
@@ -14,6 +14,9 @@ impl_op! {
         for Scalar(a: f32) -> u64 {
             a.to_bits() as u64
         }
+        for Neon(a: float32x4_t) -> int8x16_t {
+            vreinterpretq_s8_f32(a)
+        }
     }
 }
 
@@ -30,6 +33,9 @@ impl_op! {
         }
         for Scalar(a: u64) -> f32 {
             f32::from_bits(a as u32)
+        }
+        for Neon(a: int8x16_t) -> float32x4_t {
+            vreinterpretq_f32_s8(a)
         }
     }
 }
@@ -48,6 +54,9 @@ impl_op! {
         for Scalar(a: f64) -> u64 {
             a.to_bits()
         }
+        for Neon(a: float64x2_t) -> int8x16_t {
+            vreinterpretq_s8_f64(a)
+        }
     }
 }
 
@@ -64,6 +73,9 @@ impl_op! {
         }
         for Scalar(a: u64) -> f64 {
             f64::from_bits(a)
+        }
+        for Neon(a: int8x16_t) -> float64x2_t {
+            vreinterpretq_f64_s8(a)
         }
     }
 }
@@ -82,6 +94,9 @@ impl_op! {
         for Scalar(a: i8) -> u64 {
             a as u64
         }
+        for Neon(a: int8x16_t) -> int8x16_t {
+            a
+        }
     }
 }
 
@@ -98,6 +113,9 @@ impl_op! {
         }
         for Scalar(a: u64) -> i8 {
             a as i8
+        }
+        for Neon(a: int8x16_t) -> int8x16_t {
+            a
         }
     }
 }
@@ -116,6 +134,9 @@ impl_op! {
         for Scalar(a: i16) -> u64 {
             a as u64
         }
+        for Neon(a: int16x8_t) -> int8x16_t {
+            vreinterpretq_s8_s16(a)
+        }
     }
 }
 
@@ -132,6 +153,9 @@ impl_op! {
         }
         for Scalar(a: u64) -> i16 {
             a as i16
+        }
+        for Neon(a: int8x16_t) -> int16x8_t {
+            vreinterpretq_s16_s8(a)
         }
     }
 }
@@ -150,6 +174,9 @@ impl_op! {
         for Scalar(a: i32) -> u64 {
             a as u64
         }
+        for Neon(a: int32x4_t) -> int8x16_t {
+            vreinterpretq_s8_s32(a)
+        }
     }
 }
 
@@ -166,6 +193,9 @@ impl_op! {
         }
         for Scalar(a: u64) -> i32 {
             a as i32
+        }
+        for Neon(a: int8x16_t) -> int32x4_t {
+            vreinterpretq_s32_s8(a)
         }
     }
 }
@@ -184,6 +214,9 @@ impl_op! {
         for Scalar(a: i64) -> u64 {
             a as u64
         }
+        for Neon(a: int64x2_t) -> int8x16_t {
+            vreinterpretq_s8_s64(a)
+        }
     }
 }
 
@@ -200,6 +233,9 @@ impl_op! {
         }
         for Scalar(a: u64) -> i64 {
             a as i64
+        }
+        for Neon(a: int8x16_t) -> int64x2_t {
+            vreinterpretq_s64_s8(a)
         }
     }
 }

--- a/src/ops/f32.rs
+++ b/src/ops/f32.rs
@@ -14,6 +14,9 @@ impl_op! {
         for Scalar(a: f32, b: f32) -> f32 {
             a + b
         }
+        for Neon(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+            vaddq_f32(a, b)
+        }
     }
 }
 
@@ -30,6 +33,9 @@ impl_op! {
         }
         for Scalar(a: f32, b: f32) -> f32 {
             a - b
+        }
+        for Neon(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+            vsubq_f32(a, b)
         }
     }
 }
@@ -48,6 +54,9 @@ impl_op! {
         for Scalar(a: f32, b: f32) -> f32 {
             a * b
         }
+        for Neon(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+            vmulq_f32(a, b)
+        }
     }
 }
 
@@ -64,6 +73,9 @@ impl_op! {
         }
         for Scalar(a: f32, b: f32) -> f32 {
             a / b
+        }
+        for Neon(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+            vdivq_f32(a, b)
         }
     }
 }
@@ -82,6 +94,9 @@ impl_op! {
         for Scalar(a: f32, b: f32, c: f32) -> f32 {
             a * b + c
         }
+        for Neon(a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
+            vfmaq_f32(c, a, b)
+        }
     }
 }
 
@@ -99,6 +114,9 @@ impl_op! {
         for Scalar(a: f32, b: f32, c: f32) -> f32 {
             a * b - c
         }
+        for Neon(a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
+            vnegq_f32(vfmsq_f32(c, a, b))
+        }
     }
 }
 
@@ -115,6 +133,9 @@ impl_op! {
         }
         for Scalar(a: f32, b: f32, c: f32) -> f32 {
             c - a * b
+        }
+        for Neon(a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
+            vfmaq_f32(c, vnegq_f32(a), b)
         }
     }
 }
@@ -137,6 +158,9 @@ impl_op! {
         for Scalar(a: f32, b: f32, c: f32) -> f32 {
             -a * b - c
         }
+        for Neon(a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
+            vnegq_f32(vfmaq_f32(c, a, b))
+        }
     }
 }
 
@@ -153,6 +177,9 @@ impl_op! {
         }
         for Scalar(a: f32) -> f32 {
             a.m_sqrt()
+        }
+        for Neon(a: float32x4_t) -> float32x4_t {
+            vsqrtq_f32(a)
         }
     }
 }
@@ -171,6 +198,9 @@ impl_op! {
         for Scalar(a: f32) -> f32 {
             1.0 / a
         }
+        for Neon(a: float32x4_t) -> float32x4_t {
+            vrecpeq_f32(a)
+        }
     }
 }
 
@@ -187,6 +217,9 @@ impl_op! {
         }
         for Scalar(a: f32) -> f32 {
             1.0 / a.m_sqrt()
+        }
+        for Neon(a: float32x4_t) -> float32x4_t {
+            vrsqrteq_f32(a)
         }
     }
 }
@@ -205,6 +238,9 @@ impl_op! {
         for Scalar(a: f32, b: f32) -> f32 {
             a.min(b)
         }
+        for Neon(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+            vminq_f32(a, b)
+        }
     }
 }
 
@@ -222,6 +258,9 @@ impl_op! {
         for Scalar(a: f32, b: f32) -> f32 {
             a.max(b)
         }
+        for Neon(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+            vmaxq_f32(a, b)
+        }
     }
 }
 
@@ -238,6 +277,9 @@ impl_op! {
         }
         for Scalar(a: f32) -> f32 {
             a.m_abs()
+        }
+        for Neon(a: float32x4_t) -> float32x4_t {
+            vabsq_f32(a)
         }
     }
 }
@@ -260,6 +302,9 @@ impl_op! {
         }
         for Scalar(a: f32) -> f32 {
             a.m_round()
+        }
+        for Neon(a: float32x4_t) -> float32x4_t {
+            vrndaq_f32(a)
         }
     }
 }
@@ -285,6 +330,9 @@ impl_op! {
         for Scalar(a: f32) -> f32 {
             a.m_floor()
         }
+        for Neon(a: float32x4_t) -> float32x4_t {
+            vrndmq_f32(a)
+        }
     }
 }
 
@@ -309,6 +357,9 @@ impl_op! {
         for Scalar(a: f32) -> f32 {
             a.m_ceil()
         }
+        for Neon(a: float32x4_t) -> float32x4_t {
+            vrndpq_f32(a)
+        }
     }
 }
 
@@ -324,6 +375,9 @@ impl_op! {
             Self::round(a)
         }
         for Scalar(a: f32) -> f32 {
+            Self::round(a)
+        }
+        for Neon(a: float32x4_t) -> float32x4_t {
             Self::round(a)
         }
     }
@@ -343,6 +397,9 @@ impl_op! {
         for Scalar(a: f32) -> f32 {
             Self::floor(a)
         }
+        for Neon(a: float32x4_t) -> float32x4_t {
+            Self::floor(a)
+        }
     }
 }
 
@@ -358,6 +415,9 @@ impl_op! {
             Self::ceil(a)
         }
         for Scalar(a: f32) -> f32 {
+            Self::ceil(a)
+        }
+        for Neon(a: float32x4_t) -> float32x4_t {
             Self::ceil(a)
         }
     }
@@ -381,6 +441,9 @@ impl_op! {
                 0.0
             }
         }
+        for Neon(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+            vreinterpretq_f32_u32(vceqq_f32(a, b))
+        }
     }
 }
 
@@ -401,6 +464,9 @@ impl_op! {
             } else {
                 0.0
             }
+        }
+        for Neon(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+            vreinterpretq_f32_u32(vmvnq_u32(vceqq_f32(a, b)))
         }
     }
 }
@@ -423,6 +489,9 @@ impl_op! {
                 0.0
             }
         }
+        for Neon(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+            vreinterpretq_f32_u32(vcltq_f32(a, b))
+        }
     }
 }
 
@@ -443,6 +512,9 @@ impl_op! {
             } else {
                 0.0
             }
+        }
+        for Neon(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+            vreinterpretq_f32_u32(vcleq_f32(a, b))
         }
     }
 }
@@ -465,6 +537,9 @@ impl_op! {
                 0.0
             }
         }
+        for Neon(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+            vreinterpretq_f32_u32(vcgtq_f32(a, b))
+        }
     }
 }
 
@@ -486,6 +561,9 @@ impl_op! {
                 0.0
             }
         }
+        for Neon(a: float32x4_t, b: float32x4_t) -> float32x4_t {
+            vreinterpretq_f32_u32(vcgeq_f32(a, b))
+        }
     }
 }
 
@@ -506,6 +584,9 @@ impl_op! {
             } else {
                 b
             }
+        }
+        for Neon(a: float32x4_t, b: float32x4_t, mask: float32x4_t) -> float32x4_t {
+            vbslq_f32(vreinterpretq_u32_f32(mask), b, a)
         }
     }
 }
@@ -536,6 +617,11 @@ impl_op! {
         for Scalar(a: f32) -> f32 {
             a
         }
+        for Neon(a: float32x4_t) -> f32 {
+            let a = vpaddq_f32(a, a);
+            let a = vpaddq_f32(a, a);
+            vgetq_lane_f32(a, 0)
+        }
     }
 }
 
@@ -552,6 +638,11 @@ impl_op! {
         }
         for Scalar(a: f32) -> i32 {
             a.m_round() as i32
+        }
+        for Neon(a: float32x4_t) -> int32x4_t {
+            // Because other intrinsics round instead of flooring, we round here first.
+            let a = vrndnq_f32(a);
+            vcvtq_s32_f32(a)
         }
     }
 }
@@ -570,6 +661,9 @@ impl_op! {
         for Scalar(a: f32) -> i32 {
             a.to_bits() as i32
         }
+        for Neon(a: float32x4_t) -> int32x4_t {
+            vreinterpretq_s32_f32(a)
+        }
     }
 }
 
@@ -586,6 +680,9 @@ impl_op! {
         }
         for Scalar() -> f32 {
             0.0
+        }
+        for Neon() -> float32x4_t {
+            vdupq_n_f32(0.0)
         }
     }
 }
@@ -604,6 +701,9 @@ impl_op! {
         for Scalar(val: f32) -> f32 {
             val
         }
+        for Neon(val: f32) -> float32x4_t {
+            vdupq_n_f32(val)
+        }
     }
 }
 
@@ -620,6 +720,9 @@ impl_op! {
         }
         for Scalar(ptr: *const f32) -> f32 {
             unsafe { *ptr }
+        }
+        for Neon(ptr: *const f32) -> float32x4_t {
+            vld1q_f32(ptr)
         }
     }
 }
@@ -638,6 +741,9 @@ impl_op! {
         for Scalar(ptr: *const f32) -> f32 {
             unsafe { *ptr }
         }
+        for Neon(ptr: *const f32) -> float32x4_t {
+            vld1q_f32(ptr)
+        }
     }
 }
 
@@ -655,6 +761,9 @@ impl_op! {
         for Scalar(ptr: *mut f32, a: f32) {
             unsafe { *ptr = a }
         }
+        for Neon(ptr: *mut f32, a: float32x4_t) {
+            vst1q_f32(ptr, a)
+        }
     }
 }
 
@@ -671,6 +780,9 @@ impl_op! {
         }
         for Scalar(ptr: *mut f32, a: f32) {
             unsafe { *ptr = a }
+        }
+        for Neon(ptr: *mut f32, a: float32x4_t) {
+            vst1q_f32(ptr, a)
         }
     }
 }

--- a/src/ops/f64.rs
+++ b/src/ops/f64.rs
@@ -14,6 +14,9 @@ impl_op! {
         for Scalar(a: f64, b: f64) -> f64 {
             a + b
         }
+        for Neon(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+            vaddq_f64(a, b)
+        }
     }
 }
 
@@ -30,6 +33,9 @@ impl_op! {
         }
         for Scalar(a: f64, b: f64) -> f64 {
             a - b
+        }
+        for Neon(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+            vsubq_f64(a, b)
         }
     }
 }
@@ -48,6 +54,9 @@ impl_op! {
         for Scalar(a: f64, b: f64) -> f64 {
             a * b
         }
+        for Neon(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+            vmulq_f64(a, b)
+        }
     }
 }
 
@@ -64,6 +73,9 @@ impl_op! {
         }
         for Scalar(a: f64, b: f64) -> f64 {
             a / b
+        }
+        for Neon(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+            vdivq_f64(a, b)
         }
     }
 }
@@ -82,6 +94,9 @@ impl_op! {
         for Scalar(a: f64, b: f64, c: f64) -> f64 {
             a * b + c
         }
+        for Neon(a: float64x2_t, b: float64x2_t, c: float64x2_t) -> float64x2_t {
+            vmlaq_f64(c, a, b)
+        }
     }
 }
 
@@ -99,6 +114,9 @@ impl_op! {
         for Scalar(a: f64, b: f64, c: f64) -> f64 {
             a * b - c
         }
+        for Neon(a: float64x2_t, b: float64x2_t, c: float64x2_t) -> float64x2_t {
+            vnegq_f64(vfmsq_f64(c, a, b))
+        }
     }
 }
 
@@ -115,6 +133,9 @@ impl_op! {
         }
         for Scalar(a: f64, b: f64, c: f64) -> f64 {
             c - a * b
+        }
+        for Neon(a: float64x2_t, b: float64x2_t, c: float64x2_t) -> float64x2_t {
+            vfmaq_f64(c, vnegq_f64(a), b)
         }
     }
 }
@@ -137,6 +158,9 @@ impl_op! {
         for Scalar(a: f64, b: f64, c: f64) -> f64 {
             -a * b - c
         }
+        for Neon(a: float64x2_t, b: float64x2_t, c: float64x2_t) -> float64x2_t {
+            vnegq_f64(vfmaq_f64(c, a, b))
+        }
     }
 }
 
@@ -153,6 +177,9 @@ impl_op! {
         }
         for Scalar(a: f64) -> f64 {
             a.m_sqrt()
+        }
+        for Neon(a: float64x2_t) -> float64x2_t {
+            vsqrtq_f64(a)
         }
     }
 }
@@ -174,6 +201,9 @@ impl_op! {
         for Scalar(a: f64) -> f64 {
             1.0 / a.m_sqrt()
         }
+        for Neon(a: float64x2_t) -> float64x2_t {
+            vrsqrteq_f64(a)
+        }
     }
 }
 
@@ -190,6 +220,9 @@ impl_op! {
         }
         for Scalar(a: f64, b: f64) -> f64 {
             a.min(b)
+        }
+        for Neon(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+            vminq_f64(a, b)
         }
     }
 }
@@ -208,6 +241,9 @@ impl_op! {
         for Scalar(a: f64, b: f64) -> f64 {
             a.max(b)
         }
+        for Neon(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+            vmaxq_f64(a, b)
+        }
     }
 }
 
@@ -224,6 +260,9 @@ impl_op! {
         }
         for Scalar(a: f64) -> f64 {
             a.m_abs()
+        }
+        for Neon(a: float64x2_t) -> float64x2_t {
+            vabsq_f64(a)
         }
     }
 }
@@ -249,6 +288,9 @@ impl_op! {
         for Scalar(a: f64) -> f64 {
             a.m_round()
         }
+        for Neon(a: float64x2_t) -> float64x2_t {
+            vrndnq_f64(a)
+        }
     }
 }
 
@@ -270,6 +312,9 @@ impl_op! {
         }
         for Scalar(a: f64) -> f64 {
             a.m_floor()
+        }
+        for Neon(a: float64x2_t) -> float64x2_t {
+            vrndmq_f64(a)
         }
     }
 }
@@ -293,6 +338,9 @@ impl_op! {
         for Scalar(a: f64) -> f64 {
             a.m_ceil()
         }
+        for Neon(a: float64x2_t) -> float64x2_t {
+            vrndpq_f64(a)
+        }
     }
 }
 
@@ -308,6 +356,9 @@ impl_op! {
             Self::round(a)
         }
         for Scalar(a: f64) -> f64 {
+            Self::round(a)
+        }
+        for Neon(a: float64x2_t) -> float64x2_t {
             Self::round(a)
         }
     }
@@ -327,6 +378,9 @@ impl_op! {
         for Scalar(a: f64) -> f64 {
             Self::floor(a)
         }
+        for Neon(a: float64x2_t) -> float64x2_t {
+            Self::floor(a)
+        }
     }
 }
 
@@ -342,6 +396,9 @@ impl_op! {
             Self::ceil(a)
         }
         for Scalar(a: f64) -> f64 {
+            Self::ceil(a)
+        }
+        for Neon(a: float64x2_t) -> float64x2_t {
             Self::ceil(a)
         }
     }
@@ -365,6 +422,9 @@ impl_op! {
                 0.0
             }
         }
+        for Neon(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+            vreinterpretq_f64_u64(vceqq_f64(a, b))
+        }
     }
 }
 
@@ -385,6 +445,9 @@ impl_op! {
             } else {
                 0.0
             }
+        }
+        for Neon(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+            vreinterpretq_f64_u32(vmvnq_u32(vreinterpretq_u32_u64(vceqq_f64(a, b))))
         }
     }
 }
@@ -407,6 +470,9 @@ impl_op! {
                 0.0
             }
         }
+        for Neon(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+            vreinterpretq_f64_u64(vcltq_f64(a, b))
+        }
     }
 }
 
@@ -427,6 +493,9 @@ impl_op! {
             } else {
                 0.0
             }
+        }
+        for Neon(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+            vreinterpretq_f64_u64(vcleq_f64(a, b))
         }
     }
 }
@@ -449,6 +518,9 @@ impl_op! {
                 0.0
             }
         }
+        for Neon(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+            vreinterpretq_f64_u64(vcgtq_f64(a, b))
+        }
     }
 }
 
@@ -470,6 +542,9 @@ impl_op! {
                 0.0
             }
         }
+        for Neon(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+            vreinterpretq_f64_u64(vcgeq_f64(a, b))
+        }
     }
 }
 
@@ -490,6 +565,9 @@ impl_op! {
             } else {
                 b
             }
+        }
+        for Neon(a: float64x2_t, b: float64x2_t, mask: float64x2_t) -> float64x2_t {
+            vbslq_f64(vreinterpretq_u64_f64(mask), b, a)
         }
     }
 }
@@ -523,6 +601,10 @@ impl_op! {
         }
         for Scalar(a: f64) -> f64 {
             a
+        }
+        for Neon(a: float64x2_t) -> f64 {
+            let a = vpaddq_f64(a, a);
+            vgetq_lane_f64(a, 0) + vgetq_lane_f64(a, 1)
         }
     }
 }
@@ -558,6 +640,14 @@ impl_op! {
         for Scalar(a: f64) -> i64 {
             a.m_round() as i64
         }
+        for Neon(a: float64x2_t) -> int64x2_t {
+            let nums_arr = core::mem::transmute::<_, [f64; 2]>(a);
+            let ceil = [
+                nums_arr[0].m_round() as i64,
+                nums_arr[1].m_round() as i64,
+            ];
+            core::mem::transmute::<_, int64x2_t>(ceil)
+        }
     }
 }
 
@@ -574,6 +664,9 @@ impl_op! {
         }
         for Scalar(a: f64) -> i64 {
             a.to_bits() as i64
+        }
+        for Neon(a: float64x2_t) -> int64x2_t {
+            vreinterpretq_s64_f64(a)
         }
     }
 }
@@ -592,6 +685,9 @@ impl_op! {
         for Scalar() -> f64 {
             0.0
         }
+        for Neon() -> float64x2_t {
+            vdupq_n_f64(0.0)
+        }
     }
 }
 
@@ -608,6 +704,9 @@ impl_op! {
         }
         for Scalar(val: f64) -> f64 {
             val
+        }
+        for Neon(val: f64) -> float64x2_t {
+            vdupq_n_f64(val)
         }
     }
 }
@@ -626,6 +725,9 @@ impl_op! {
         for Scalar(ptr: *const f64) -> f64 {
             unsafe { *ptr }
         }
+        for Neon(ptr: *const f64) -> float64x2_t {
+            vld1q_f64(ptr)
+        }
     }
 }
 
@@ -642,6 +744,9 @@ impl_op! {
         }
         for Scalar(ptr: *const f64) -> f64 {
             unsafe { *ptr }
+        }
+        for Neon(ptr: *const f64) -> float64x2_t {
+            vld1q_f64(ptr)
         }
     }
 }
@@ -660,6 +765,9 @@ impl_op! {
         for Scalar(ptr: *mut f64, a: f64) {
             unsafe { *ptr = a }
         }
+        for Neon(ptr: *mut f64, a: float64x2_t) {
+            vst1q_f64(ptr, a)
+        }
     }
 }
 
@@ -676,6 +784,9 @@ impl_op! {
         }
         for Scalar(ptr: *mut f64, a: f64) {
             unsafe { *ptr = a }
+        }
+        for Neon(ptr: *mut f64, a: float64x2_t) {
+            vst1q_f64(ptr, a)
         }
     }
 }

--- a/src/ops/i16.rs
+++ b/src/ops/i16.rs
@@ -14,6 +14,9 @@ impl_op! {
         for Scalar(a: i16, b: i16) -> i16 {
             a.wrapping_add(b)
         }
+        for Neon(a: int16x8_t, b: int16x8_t) -> int16x8_t {
+            vaddq_s16(a, b)
+        }
     }
 }
 
@@ -30,6 +33,9 @@ impl_op! {
         }
         for Scalar(a: i16, b: i16) -> i16 {
             a.wrapping_sub(b)
+        }
+        for Neon(a: int16x8_t, b: int16x8_t) -> int16x8_t {
+            vsubq_s16(a, b)
         }
     }
 }
@@ -48,6 +54,9 @@ impl_op! {
         for Scalar(a: i16, b: i16) -> i16 {
             a.wrapping_mul(b)
         }
+        for Neon(a: int16x8_t, b: int16x8_t) -> int16x8_t {
+            vmulq_s16(a, b)
+        }
     }
 }
 
@@ -64,6 +73,9 @@ impl_op! {
         }
         for Scalar(a: i16, b: i16) -> i16 {
             a.min(b)
+        }
+        for Neon(a: int16x8_t, b: int16x8_t) -> int16x8_t {
+            vminq_s16(a, b)
         }
     }
 }
@@ -82,6 +94,9 @@ impl_op! {
         for Scalar(a: i16, b: i16) -> i16 {
             a.max(b)
         }
+        for Neon(a: int16x8_t, b: int16x8_t) -> int16x8_t {
+            vmaxq_s16(a, b)
+        }
     }
 }
 
@@ -99,6 +114,9 @@ impl_op! {
         }
         for Scalar(a: i16) -> i16 {
             a.abs()
+        }
+        for Neon(a: int16x8_t) -> int16x8_t {
+            vabsq_s16(a)
         }
     }
 }
@@ -120,6 +138,9 @@ impl_op! {
             } else {
                 0
             }
+        }
+        for Neon(a: int16x8_t, b: int16x8_t) -> int16x8_t {
+            vreinterpretq_s16_u16(vceqq_s16(a, b))
         }
     }
 }
@@ -144,6 +165,9 @@ impl_op! {
             } else {
                 0
             }
+        }
+        for Neon(a: int16x8_t, b: int16x8_t) -> int16x8_t {
+            vreinterpretq_s16_u16(vmvnq_u16(vceqq_s16(a, b)))
         }
     }
 }
@@ -172,6 +196,9 @@ impl_op! {
                 0
             }
         }
+        for Neon(a: int16x8_t, b: int16x8_t) -> int16x8_t {
+            vreinterpretq_s16_u16(vcltq_s16(a, b))
+        }
     }
 }
 
@@ -196,6 +223,9 @@ impl_op! {
                 0
             }
         }
+        for Neon(a: int16x8_t, b: int16x8_t) -> int16x8_t {
+            vreinterpretq_s16_u16(vcleq_s16(a, b))
+        }
     }
 }
 
@@ -216,6 +246,9 @@ impl_op! {
             } else {
                 0
             }
+        }
+        for Neon(a: int16x8_t, b: int16x8_t) -> int16x8_t {
+            vreinterpretq_s16_u16(vcgtq_s16(a, b))
         }
     }
 }
@@ -244,6 +277,9 @@ impl_op! {
                 0
             }
         }
+        for Neon(a: int16x8_t, b: int16x8_t) -> int16x8_t {
+            vreinterpretq_s16_u16(vcgeq_s16(a, b))
+        }
     }
 }
 
@@ -265,6 +301,9 @@ impl_op! {
                 b
             }
         }
+        for Neon(a: int16x8_t, b: int16x8_t, mask: int16x8_t) -> int16x8_t {
+            vbslq_s16(vreinterpretq_u16_s16(mask), b, a)
+        }
     }
 }
 
@@ -281,6 +320,10 @@ impl_op! {
         }
         for Scalar(a: i16, rhs: i32) -> i16 {
             a << rhs
+        }
+        for Neon(a: int16x8_t, rhs: i32) -> int16x8_t {
+            let rhs = Self::set1(rhs as i16);
+            vshlq_s16(a, rhs)
         }
     }
 }
@@ -299,6 +342,10 @@ impl_op! {
         for Scalar(a: i16, rhs: i32) -> i16 {
             ((a as u16) >> rhs) as i16
         }
+        for Neon(a: int16x8_t, rhs: i32) -> int16x8_t {
+            let rhs = Self::set1(-rhs as i16);
+            vreinterpretq_s16_u16(vshlq_u16(vreinterpretq_u16_s16(a), rhs))
+        }
     }
 }
 
@@ -316,6 +363,9 @@ impl_imm8_op! {
         for Scalar(a: i16) -> i16 {
             a << BY
         }
+        for Neon(a: int16x8_t) -> int16x8_t {
+            vshlq_n_s16(a, BY)
+        }
     }
 }
 
@@ -332,6 +382,9 @@ impl_imm8_op! {
         }
         for Scalar(a: i16) -> i16 {
             ((a as u16) >> BY) as i16
+        }
+        for Neon(a: int16x8_t) -> int16x8_t {
+            vreinterpretq_s16_u16(vshrq_n_u16(vreinterpretq_u16_s16(a), BY))
         }
     }
 }
@@ -367,6 +420,11 @@ impl_op! {
         for Scalar(val: i16) -> (i32, i32) {
             (val as i32, 0)
         }
+        for Neon(val: int16x8_t) -> (int32x4_t, int32x4_t) {
+            let a = vmovl_s16(vget_low_s16(val));
+            let b = vmovl_s16(vget_high_s16(val));
+            (a, b)
+        }
     }
 }
 
@@ -401,6 +459,11 @@ impl_op! {
         for Scalar(val: i16) -> (i32, i32) {
             (val as u16 as u32 as i32, 0)
         }
+        for Neon(val: int16x8_t) -> (int32x4_t, int32x4_t) {
+            let a = vreinterpretq_s32_u32(vmovl_u16(vreinterpret_u16_s16(vget_low_s16(val))));
+            let b = vreinterpretq_s32_u32(vmovl_u16(vreinterpret_u16_s16(vget_high_s16(val))));
+            (a, b)
+        }
     }
 }
 
@@ -417,6 +480,9 @@ impl_op! {
         }
         for Scalar() -> i16 {
             0
+        }
+        for Neon() -> int16x8_t {
+            vdupq_n_s16(0)
         }
     }
 }
@@ -435,6 +501,9 @@ impl_op! {
         for Scalar(val: i16) -> i16 {
             val
         }
+        for Neon(val: i16) -> int16x8_t {
+            vdupq_n_s16(val)
+        }
     }
 }
 
@@ -451,6 +520,9 @@ impl_op! {
         }
         for Scalar(ptr: *const i16) -> i16 {
             unsafe { *ptr }
+        }
+        for Neon(ptr: *const i16) -> int16x8_t {
+            vld1q_s16(ptr as *const i16)
         }
     }
 }
@@ -469,6 +541,9 @@ impl_op! {
         for Scalar(ptr: *const i16) -> i16 {
             unsafe { *ptr }
         }
+        for Neon(ptr: *const i16) -> int16x8_t {
+            vld1q_s16(ptr as *const i16)
+        }
     }
 }
 
@@ -486,6 +561,9 @@ impl_op! {
         for Scalar(ptr: *mut i16, a: i16) {
             unsafe { *ptr = a }
         }
+        for Neon(ptr: *mut i16, a: int16x8_t) {
+            vst1q_s16(ptr as *mut i16, a)
+        }
     }
 }
 
@@ -502,6 +580,9 @@ impl_op! {
         }
         for Scalar(ptr: *mut i16, a: i16) {
             unsafe { *ptr = a }
+        }
+        for Neon(ptr: *mut i16, a: int16x8_t) {
+            vst1q_s16(ptr as *mut i16, a)
         }
     }
 }

--- a/src/ops/i32.rs
+++ b/src/ops/i32.rs
@@ -14,6 +14,9 @@ impl_op! {
         for Scalar(a: i32, b: i32) -> i32 {
             a.wrapping_add(b)
         }
+        for Neon(a: int32x4_t, b: int32x4_t) -> int32x4_t {
+            vaddq_s32(a, b)
+        }
     }
 }
 
@@ -30,6 +33,9 @@ impl_op! {
         }
         for Scalar(a: i32, b: i32) -> i32 {
             a.wrapping_sub(b)
+        }
+        for Neon(a: int32x4_t, b: int32x4_t) -> int32x4_t {
+            vsubq_s32(a, b)
         }
     }
 }
@@ -56,6 +62,9 @@ impl_op! {
         for Scalar(a: i32, b: i32) -> i32 {
             a.wrapping_mul(b)
         }
+        for Neon(a: int32x4_t, b: int32x4_t) -> int32x4_t {
+            vmulq_s32(a, b)
+        }
     }
 }
 
@@ -73,6 +82,9 @@ impl_op! {
         }
         for Scalar(a: i32, b: i32) -> i32 {
             a.min(b)
+        }
+        for Neon(a: int32x4_t, b: int32x4_t) -> int32x4_t {
+            vminq_s32(a, b)
         }
     }
 }
@@ -92,6 +104,9 @@ impl_op! {
         for Scalar(a: i32, b: i32) -> i32 {
             a.max(b)
         }
+        for Neon(a: int32x4_t, b: int32x4_t) -> int32x4_t {
+            vmaxq_s32(a, b)
+        }
     }
 }
 
@@ -109,6 +124,9 @@ impl_op! {
         }
         for Scalar(a: i32) -> i32 {
             a.abs()
+        }
+        for Neon(a: int32x4_t) -> int32x4_t {
+            vabsq_s32(a)
         }
     }
 }
@@ -130,6 +148,9 @@ impl_op! {
             } else {
                 0
             }
+        }
+        for Neon(a: int32x4_t, b: int32x4_t) -> int32x4_t {
+            vreinterpretq_s32_u32(vceqq_s32(a, b))
         }
     }
 }
@@ -154,6 +175,9 @@ impl_op! {
             } else {
                 0
             }
+        }
+        for Neon(a: int32x4_t, b: int32x4_t) -> int32x4_t {
+            vreinterpretq_s32_u32(vmvnq_u32(vceqq_s32(a, b)))
         }
     }
 }
@@ -182,6 +206,9 @@ impl_op! {
                 0
             }
         }
+        for Neon(a: int32x4_t, b: int32x4_t) -> int32x4_t {
+            vreinterpretq_s32_u32(vcltq_s32(a, b))
+        }
     }
 }
 
@@ -206,6 +233,9 @@ impl_op! {
                 0
             }
         }
+        for Neon(a: int32x4_t, b: int32x4_t) -> int32x4_t {
+            vreinterpretq_s32_u32(vcleq_s32(a, b))
+        }
     }
 }
 
@@ -226,6 +256,9 @@ impl_op! {
             } else {
                 0
             }
+        }
+        for Neon(a: int32x4_t, b: int32x4_t) -> int32x4_t {
+            vreinterpretq_s32_u32(vcgtq_s32(a, b))
         }
     }
 }
@@ -254,6 +287,9 @@ impl_op! {
                 0
             }
         }
+        for Neon(a: int32x4_t, b: int32x4_t) -> int32x4_t {
+            vreinterpretq_s32_u32(vcgeq_s32(a, b))
+        }
     }
 }
 
@@ -275,6 +311,9 @@ impl_op! {
                 b
             }
         }
+        for Neon(a: int32x4_t, b: int32x4_t, mask: int32x4_t) -> int32x4_t {
+            vbslq_s32(vreinterpretq_u32_s32(mask), b, a)
+        }
     }
 }
 
@@ -283,14 +322,18 @@ impl_op! {
         for Avx2(a: __m256i, rhs: i32) -> __m256i {
             _mm256_sll_epi32(a, _mm_cvtsi32_si128(rhs))
         }
-        for Sse41(a: __m128i, b: i32) -> __m128i {
-            _mm_sll_epi32(a, _mm_cvtsi32_si128(b))
+        for Sse41(a: __m128i, rhs: i32) -> __m128i {
+            _mm_sll_epi32(a, _mm_cvtsi32_si128(rhs))
         }
-        for Sse2(a: __m128i, b: i32) -> __m128i {
-            _mm_sll_epi32(a, _mm_cvtsi32_si128(b))
+        for Sse2(a: __m128i, rhs: i32) -> __m128i {
+            _mm_sll_epi32(a, _mm_cvtsi32_si128(rhs))
         }
-        for Scalar(a: i32, b: i32) -> i32 {
-            a << b
+        for Scalar(a: i32, rhs: i32) -> i32 {
+            a << rhs
+        }
+        for Neon(a: int32x4_t, rhs: i32) -> int32x4_t {
+            let rhs = Self::set1(rhs as i32);
+            vshlq_s32(a, rhs)
         }
     }
 }
@@ -309,6 +352,10 @@ impl_op! {
         for Scalar(a: i32, rhs: i32) -> i32 {
             ((a as u32) >> rhs) as i32
         }
+        for Neon(a: int32x4_t, rhs: i32) -> int32x4_t {
+            let rhs = Self::set1(-rhs);
+            vreinterpretq_s32_u32(vshlq_u32(vreinterpretq_u32_s32(a), rhs))
+        }
     }
 }
 
@@ -325,6 +372,9 @@ impl_imm8_op! {
         }
         for Scalar(a: i32) -> i32 {
             a << BY
+        }
+        for Neon(a: int32x4_t) -> int32x4_t {
+            vshlq_n_s32(a, BY)
         }
     }
 }
@@ -343,6 +393,9 @@ impl_imm8_op! {
         for Scalar(a: i32) -> i32 {
             ((a as u32) >> BY) as i32
         }
+        for Neon(a: int32x4_t) -> int32x4_t {
+            vreinterpretq_s32_u32(vshrq_n_u32(vreinterpretq_u32_s32(a), BY))
+        }
     }
 }
 
@@ -360,6 +413,9 @@ impl_op! {
         for Scalar(a: i32) -> f32 {
             a as f32
         }
+        for Neon(a: int32x4_t) -> float32x4_t {
+            vcvtq_f32_s32(a)
+        }
     }
 }
 
@@ -376,6 +432,9 @@ impl_op! {
         }
         for Scalar(a: i32) -> f32 {
             f32::from_bits(a as u32)
+        }
+        for Neon(a: int32x4_t) -> float32x4_t {
+            core::mem::transmute(a)
         }
     }
 }
@@ -399,6 +458,11 @@ impl_op! {
         for Scalar(val: i32) -> (i64, i64) {
             (val as i64, 0)
         }
+        for Neon(val: int32x4_t) -> (int64x2_t, int64x2_t) {
+            let a = vmovl_s32(vget_low_s32(val));
+            let b = vmovl_s32(vget_high_s32(val));
+            (a, b)
+        }
     }
 }
 
@@ -421,6 +485,11 @@ impl_op! {
         for Scalar(val: i32) -> (i64, i64) {
             (val as u32 as u64 as i64, 0)
         }
+        for Neon(val: int32x4_t) -> (int64x2_t, int64x2_t) {
+            let a = vreinterpretq_s64_u64(vmovl_u32(vreinterpret_u32_s32(vget_low_s32(val))));
+            let b = vreinterpretq_s64_u64(vmovl_u32(vreinterpret_u32_s32(vget_high_s32(val))));
+            (a, b)
+        }
     }
 }
 
@@ -437,6 +506,9 @@ impl_op! {
         }
         for Scalar() -> i32 {
             0
+        }
+        for Neon() -> int32x4_t {
+            vdupq_n_s32(0)
         }
     }
 }
@@ -455,6 +527,9 @@ impl_op! {
         for Scalar(val: i32) -> i32 {
             val
         }
+        for Neon(val: i32) -> int32x4_t {
+            vdupq_n_s32(val)
+        }
     }
 }
 
@@ -471,6 +546,9 @@ impl_op! {
         }
         for Scalar(ptr: *const i32) -> i32 {
             unsafe { *ptr }
+        }
+        for Neon(ptr: *const i32) -> int32x4_t {
+            vld1q_s32(ptr)
         }
     }
 }
@@ -489,6 +567,9 @@ impl_op! {
         for Scalar(ptr: *const i32) -> i32 {
             unsafe { *ptr }
         }
+        for Neon(ptr: *const i32) -> int32x4_t {
+            vld1q_s32(ptr)
+        }
     }
 }
 
@@ -506,6 +587,9 @@ impl_op! {
         for Scalar(ptr: *mut i32, a: i32) {
             unsafe { *ptr = a }
         }
+        for Neon(ptr: *mut i32, a: int32x4_t) {
+            vst1q_s32(ptr, a)
+        }
     }
 }
 
@@ -522,6 +606,9 @@ impl_op! {
         }
         for Scalar(ptr: *mut i32, a: i32) {
             unsafe { *ptr = a }
+        }
+        for Neon(ptr: *mut i32, a: int32x4_t) {
+            vst1q_s32(ptr, a)
         }
     }
 }

--- a/src/ops/i64.rs
+++ b/src/ops/i64.rs
@@ -14,6 +14,9 @@ impl_op! {
         for Scalar(a: i64, b: i64) -> i64 {
             a.wrapping_add(b)
         }
+        for Neon(a: int64x2_t, b: int64x2_t) -> int64x2_t {
+            vaddq_s64(a, b)
+        }
     }
 }
 
@@ -30,6 +33,9 @@ impl_op! {
         }
         for Scalar(a: i64, b: i64) -> i64 {
             a.wrapping_sub(b)
+        }
+        for Neon(a: int64x2_t, b: int64x2_t) -> int64x2_t {
+            vsubq_s64(a, b)
         }
     }
 }
@@ -68,6 +74,15 @@ impl_op! {
         for Scalar(a: i64, b: i64) -> i64 {
             a.wrapping_mul(b)
         }
+        for Neon(a: int64x2_t, b: int64x2_t) -> int64x2_t {
+            let a_arr = core::mem::transmute::<_, [i64; 2]>(a);
+            let b_arr = core::mem::transmute::<_, [i64; 2]>(b);
+            let c_arr = [
+                a_arr[0].wrapping_mul(b_arr[0]),
+                a_arr[1].wrapping_mul(b_arr[1]),
+            ];
+            core::mem::transmute::<_, int64x2_t>(c_arr)
+        }
     }
 }
 
@@ -87,6 +102,11 @@ impl_op! {
         }
         for Scalar(a: i64, b: i64) -> i64 {
             a.min(b)
+        }
+        for Neon(a: int64x2_t, b: int64x2_t) -> int64x2_t {
+            let mask = vreinterpretq_s64_u64(vcgtq_s64(a, b));
+            let not_mask = vreinterpretq_s64_s32(vmvnq_s32(vreinterpretq_s32_s64(mask)));
+            vorrq_s64(vandq_s64(mask, b), vandq_s64(not_mask, a))
         }
     }
 }
@@ -108,6 +128,11 @@ impl_op! {
         for Scalar(a: i64, b: i64) -> i64 {
             a.max(b)
         }
+        for Neon(a: int64x2_t, b: int64x2_t) -> int64x2_t {
+            let mask = vreinterpretq_s64_u64(vcgtq_s64(a, b));
+            let not_mask = vreinterpretq_s64_s32(vmvnq_s32(vreinterpretq_s32_s64(mask)));
+            vorrq_s64(vandq_s64(mask, a), vandq_s64(not_mask, b))
+        }
     }
 }
 
@@ -127,6 +152,9 @@ impl_op! {
         }
         for Scalar(a: i64) -> i64 {
             a.abs()
+        }
+        for Neon(a: int64x2_t) -> int64x2_t {
+            vabsq_s64(a)
         }
     }
 }
@@ -148,6 +176,9 @@ impl_op! {
             } else {
                 0
             }
+        }
+        for Neon(a: int64x2_t, b: int64x2_t) -> int64x2_t {
+            vreinterpretq_s64_u64(vceqq_s64(a, b))
         }
     }
 }
@@ -172,6 +203,9 @@ impl_op! {
             } else {
                 0
             }
+        }
+        for Neon(a: int64x2_t, b: int64x2_t) -> int64x2_t {
+            vreinterpretq_s64_u32(vmvnq_u32(vreinterpretq_u32_u64(vceqq_s64(a, b))))
         }
     }
 }
@@ -200,6 +234,9 @@ impl_op! {
                 0
             }
         }
+        for Neon(a: int64x2_t, b: int64x2_t) -> int64x2_t {
+            vreinterpretq_s64_u64(vcltq_s64(a, b))
+        }
     }
 }
 
@@ -224,6 +261,9 @@ impl_op! {
                 0
             }
         }
+        for Neon(a: int64x2_t, b: int64x2_t) -> int64x2_t {
+            vreinterpretq_s64_u64(vcleq_s64(a, b))
+        }
     }
 }
 
@@ -244,6 +284,9 @@ impl_op! {
             } else {
                 0
             }
+        }
+        for Neon(a: int64x2_t, b: int64x2_t) -> int64x2_t {
+            vreinterpretq_s64_u64(vcgtq_s64(a, b))
         }
     }
 }
@@ -272,6 +315,9 @@ impl_op! {
                 0
             }
         }
+        for Neon(a: int64x2_t, b: int64x2_t) -> int64x2_t {
+            vreinterpretq_s64_u64(vcgeq_s64(a, b))
+        }
     }
 }
 
@@ -293,6 +339,9 @@ impl_op! {
                 b
             }
         }
+        for Neon(a: int64x2_t, b: int64x2_t, mask: int64x2_t) -> int64x2_t {
+            vbslq_s64(vreinterpretq_u64_s64(mask), b, a)
+        }
     }
 }
 
@@ -309,6 +358,10 @@ impl_op! {
         }
         for Scalar(a: i64, b: i32) -> i64 {
             a << b
+        }
+        for Neon(a: int64x2_t, rhs: i32) -> int64x2_t {
+            let rhs = Self::set1(rhs as i64);
+            vshlq_s64(a, rhs)
         }
     }
 }
@@ -327,6 +380,10 @@ impl_op! {
         for Scalar(a: i64, rhs: i32) -> i64 {
             ((a as u64) >> rhs) as i64
         }
+        for Neon(a: int64x2_t, rhs: i32) -> int64x2_t {
+            let rhs = Self::set1(-rhs as i64);
+            vreinterpretq_s64_u64(vshlq_u64(vreinterpretq_u64_s64(a), rhs))
+        }
     }
 }
 
@@ -344,6 +401,9 @@ impl_imm8_op! {
         for Scalar(a: i64) -> i64 {
             a << BY
         }
+        for Neon(a: int64x2_t) -> int64x2_t {
+            vshlq_n_s64(a, BY)
+        }
     }
 }
 
@@ -360,6 +420,9 @@ impl_imm8_op! {
         }
         for Scalar(a: i64) -> i64 {
             ((a as u64) >> BY) as i64
+        }
+        for Neon(a: int64x2_t) -> int64x2_t {
+            vreinterpretq_s64_u64(vshrq_n_u64(vreinterpretq_u64_s64(a), BY))
         }
     }
 }
@@ -395,6 +458,9 @@ impl_op! {
         for Scalar(a: i64) -> f64 {
             a as f64
         }
+        for Neon(a: int64x2_t) -> float64x2_t {
+            vcvtq_f64_s64(a)
+        }
     }
 }
 
@@ -411,6 +477,9 @@ impl_op! {
         }
         for Scalar(a: i64) -> f64 {
             f64::from_bits(a as u64)
+        }
+        for Neon(a: int64x2_t) -> float64x2_t {
+            core::mem::transmute::<_, float64x2_t>(a)
         }
     }
 }
@@ -438,6 +507,12 @@ impl_op! {
         for Scalar(val: i64) -> i64 {
             val
         }
+        for Neon(val: int64x2_t) -> i64 {
+            let a = val;
+            let b = vcombine_s64(vget_high_s64(a), vget_low_s64(a));
+            let c = vaddq_s64(a, b);
+            vgetq_lane_s64(c, 0)
+        }
     }
 }
 
@@ -454,6 +529,9 @@ impl_op! {
         }
         for Scalar() -> i64 {
             0
+        }
+        for Neon() -> int64x2_t {
+            vdupq_n_s64(0)
         }
     }
 }
@@ -472,6 +550,9 @@ impl_op! {
         for Scalar(val: i64) -> i64 {
             val
         }
+        for Neon(val: i64) -> int64x2_t {
+            vdupq_n_s64(val)
+        }
     }
 }
 
@@ -488,6 +569,9 @@ impl_op! {
         }
         for Scalar(ptr: *const i64) -> i64 {
             unsafe { *ptr }
+        }
+        for Neon(ptr: *const i64) -> int64x2_t {
+            vld1q_s64(ptr)
         }
     }
 }
@@ -506,6 +590,9 @@ impl_op! {
         for Scalar(ptr: *const i64) -> i64 {
             unsafe { *ptr }
         }
+        for Neon(ptr: *const i64) -> int64x2_t {
+            vld1q_s64(ptr)
+        }
     }
 }
 
@@ -523,6 +610,9 @@ impl_op! {
         for Scalar(ptr: *mut i64, a: i64) {
             unsafe { *ptr = a }
         }
+        for Neon(ptr: *mut i64, a: int64x2_t) {
+            vst1q_s64(ptr, a)
+        }
     }
 }
 
@@ -539,6 +629,9 @@ impl_op! {
         }
         for Scalar(ptr: *mut i64, a: i64) {
             unsafe { *ptr = a }
+        }
+        for Neon(ptr: *mut i64, a: int64x2_t) {
+            vst1q_s64(ptr, a)
         }
     }
 }

--- a/src/ops/i8.rs
+++ b/src/ops/i8.rs
@@ -14,6 +14,9 @@ impl_op! {
         for Scalar(a: i8, b: i8) -> i8 {
             a.wrapping_add(b)
         }
+        for Neon(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            vaddq_s8(a, b)
+        }
     }
 }
 
@@ -30,6 +33,9 @@ impl_op! {
         }
         for Scalar(a: i8, b: i8) -> i8 {
             a.wrapping_sub(b)
+        }
+        for Neon(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            vsubq_s8(a, b)
         }
     }
 }
@@ -63,6 +69,9 @@ impl_op! {
         for Scalar(a: i8, b: i8) -> i8 {
             a.wrapping_mul(b)
         }
+        for Neon(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            vmulq_s8(a, b)
+        }
     }
 }
 
@@ -80,6 +89,9 @@ impl_op! {
         }
         for Scalar(a: i8, b: i8) -> i8 {
             a.min(b)
+        }
+        for Neon(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            vminq_s8(a, b)
         }
     }
 }
@@ -99,6 +111,9 @@ impl_op! {
         for Scalar(a: i8, b: i8) -> i8 {
             a.max(b)
         }
+        for Neon(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            vmaxq_s8(a, b)
+        }
     }
 }
 
@@ -116,6 +131,9 @@ impl_op! {
         }
         for Scalar(a: i8) -> i8 {
             a.abs()
+        }
+        for Neon(a: int8x16_t) -> int8x16_t {
+            vabsq_s8(a)
         }
     }
 }
@@ -137,6 +155,9 @@ impl_op! {
             } else {
                 0
             }
+        }
+        for Neon(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            vreinterpretq_s8_u8(vceqq_s8(a, b))
         }
     }
 }
@@ -161,6 +182,9 @@ impl_op! {
             } else {
                 0
             }
+        }
+        for Neon(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            vreinterpretq_s8_u8(vmvnq_u8(vceqq_s8(a, b)))
         }
     }
 }
@@ -189,6 +213,9 @@ impl_op! {
                 0
             }
         }
+        for Neon(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            vreinterpretq_s8_u8(vcltq_s8(a, b))
+        }
     }
 }
 
@@ -213,6 +240,9 @@ impl_op! {
                 0
             }
         }
+        for Neon(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            vreinterpretq_s8_u8(vcleq_s8(a, b))
+        }
     }
 }
 
@@ -233,6 +263,9 @@ impl_op! {
             } else {
                 0
             }
+        }
+        for Neon(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            vreinterpretq_s8_u8(vcgtq_s8(a, b))
         }
     }
 }
@@ -261,6 +294,9 @@ impl_op! {
                 0
             }
         }
+        for Neon(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            vreinterpretq_s8_u8(vcgeq_s8(a, b))
+        }
     }
 }
 
@@ -281,6 +317,9 @@ impl_op! {
             } else {
                 b
             }
+        }
+        for Neon(a: int8x16_t, b: int8x16_t, mask: int8x16_t) -> int8x16_t {
+            vbslq_s8(vreinterpretq_u8_s8(mask), b, a)
         }
     }
 }
@@ -311,6 +350,10 @@ impl_op! {
         for Scalar(a: i8, rhs: i32) -> i8 {
             a << rhs
         }
+        for Neon(a: int8x16_t, rhs: i32) -> int8x16_t {
+            let rhs = Self::set1(rhs as i8);
+            vshlq_s8(a, rhs)
+        }
     }
 }
 
@@ -340,6 +383,10 @@ impl_op! {
         for Scalar(a: i8, rhs: i32) -> i8 {
             ((a as u8) >> rhs) as i8
         }
+        for Neon(a: int8x16_t, rhs: i32) -> int8x16_t {
+            let rhs = Self::set1(-rhs as i8);
+            vreinterpretq_s8_u8(vshlq_u8(vreinterpretq_u8_s8(a), rhs))
+        }
     }
 }
 
@@ -357,6 +404,9 @@ impl_imm8_op! {
         for Scalar(a: i8) -> i8 {
             a << BY
         }
+        for Neon(a: int8x16_t) -> int8x16_t {
+            vshlq_n_s8(a, BY)
+        }
     }
 }
 
@@ -373,6 +423,9 @@ impl_imm8_op! {
         }
         for Scalar(a: i8) -> i8 {
             ((a as u8) >> BY) as i8
+        }
+        for Neon(a: int8x16_t) -> int8x16_t {
+            vreinterpretq_s8_u8(vshrq_n_u8(vreinterpretq_u8_s8(a), BY))
         }
     }
 }
@@ -416,6 +469,11 @@ impl_op! {
         for Scalar(val: i8) -> (i16, i16) {
             (val as i16, 0)
         }
+        for Neon(val: int8x16_t) -> (int16x8_t, int16x8_t) {
+            let a = vmovl_s8(vget_low_s8(val));
+            let b = vmovl_s8(vget_high_s8(val));
+            (a, b)
+        }
     }
 }
 
@@ -458,6 +516,11 @@ impl_op! {
         for Scalar(val: i8) -> (i16, i16) {
             (val as u8 as u16 as i16, 0)
         }
+        for Neon(val: int8x16_t) -> (int16x8_t, int16x8_t) {
+            let a = vreinterpretq_s16_u16(vmovl_u8(vreinterpret_u8_s8(vget_low_s8(val))));
+            let b = vreinterpretq_s16_u16(vmovl_u8(vreinterpret_u8_s8(vget_high_s8(val))));
+            (a, b)
+        }
     }
 }
 
@@ -474,6 +537,22 @@ impl_op! {
         }
         for Scalar(val: i8) -> u32 {
             ((val as u8) & 0x80) as u32
+        }
+        for Neon(val: int8x16_t) -> u32 {
+            let val = vreinterpretq_u8_s8(val);
+
+            // Algorithm copied from here: https://stackoverflow.com/a/68694558
+            let uc_shift: [i8; 16] = [-7,-6,-5,-4,-3,-2,-1,0,-7,-6,-5,-4,-3,-2,-1,0];
+            let vshift: int8x16_t = std::mem::transmute(uc_shift);
+            let vmask = vandq_u8(val, vdupq_n_u8(0x80));
+
+            let vmask = vshlq_u8(vmask, vshift);
+
+            let mut out: u16 = 0;
+            out |= vaddv_u8(vget_low_u8(vmask)) as u16;
+            out |= (vaddv_u8(vget_high_u8(vmask)) as u16) << 8;
+
+            out as u32
         }
     }
 }
@@ -492,6 +571,9 @@ impl_op! {
         for Scalar() -> i8 {
             0
         }
+        for Neon() -> int8x16_t {
+            vdupq_n_s8(0)
+        }
     }
 }
 
@@ -508,6 +590,9 @@ impl_op! {
         }
         for Scalar(val: i8) -> i8 {
             val
+        }
+        for Neon(val: i8) -> int8x16_t {
+            vdupq_n_s8(val)
         }
     }
 }
@@ -526,6 +611,9 @@ impl_op! {
         for Scalar(ptr: *const i8) -> i8 {
             unsafe { *ptr }
         }
+        for Neon(ptr: *const i8) -> int8x16_t {
+            vld1q_s8(ptr as *const i8)
+        }
     }
 }
 
@@ -542,6 +630,9 @@ impl_op! {
         }
         for Scalar(ptr: *const i8) -> i8 {
             unsafe { *ptr }
+        }
+        for Neon(ptr: *const i8) -> int8x16_t {
+            vld1q_s8(ptr)
         }
     }
 }
@@ -560,6 +651,9 @@ impl_op! {
         for Scalar(ptr: *mut i8, a: i8) {
             unsafe { *ptr = a }
         }
+        for Neon(ptr: *mut i8, a: int8x16_t) {
+            vst1q_s8(ptr, a)
+        }
     }
 }
 
@@ -576,6 +670,9 @@ impl_op! {
         }
         for Scalar(ptr: *mut i8, a: i8) {
             unsafe { *ptr = a }
+        }
+        for Neon(ptr: *mut i8, a: int8x16_t) {
+            vst1q_s8(ptr, a)
         }
     }
 }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,14 +1,19 @@
 #![allow(dead_code)]
 
-use crate::engines::{avx2::Avx2, scalar::Scalar, sse2::Sse2, sse41::Sse41};
+use crate::engines::scalar::Scalar;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+use crate::engines::{avx2::Avx2, sse2::Sse2, sse41::Sse41};
+#[cfg(target_arch = "aarch64")]
+use crate::engines::{neon::Neon};
 use crate::libm_ext::FloatExt;
 use core::marker::PhantomData;
 
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
-
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
+#[cfg(target_arch = "aarch64")]
+use core::arch::aarch64::*;
 
 mod i8;
 pub use self::i8::*;
@@ -41,15 +46,23 @@ pub struct Ops<T, T2>(PhantomData<(T, T2)>);
 
 macro_rules! with_feature_flag {
     (Avx2, $($r:tt)+) => {
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         #[target_feature(enable = "avx2")]
         $($r)+
     };
     (Sse2, $($r:tt)+) => {
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         #[target_feature(enable = "sse2")]
         $($r)+
     };
     (Sse41, $($r:tt)+) => {
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         #[target_feature(enable = "sse4.1")]
+        $($r)+
+    };
+    (Neon, $($r:tt)+) => {
+        #[cfg(target_arch = "aarch64")]
+        #[target_feature(enable = "neon")]
         $($r)+
     };
     (Scalar, $($r:tt)+) => {
@@ -57,6 +70,29 @@ macro_rules! with_feature_flag {
     };
 }
 use with_feature_flag;
+
+macro_rules! with_cfg_flag {
+    (Avx2, $($r:tt)+) => {
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        $($r)+
+    };
+    (Sse2, $($r:tt)+) => {
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        $($r)+
+    };
+    (Sse41, $($r:tt)+) => {
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        $($r)+
+    };
+    (Neon, $($r:tt)+) => {
+        #[cfg(target_arch = "aarch64")]
+        $($r)+
+    };
+    (Scalar, $($r:tt)+) => {
+        $($r)+
+    };
+}
+use with_cfg_flag;
 
 macro_rules! impl_op {
     (fn $name:ident < $scalar:ty > {
@@ -67,15 +103,18 @@ macro_rules! impl_op {
         )*
     }) => {
         $(
-            impl Ops<$engine, $scalar> {
-                with_feature_flag!(
-                    $engine,
-                    #[inline]
-                    pub unsafe fn $name($($arg: $arg_ty),*) $( -> $ret_ty )? {
-                        $( $body )*
-                    }
-                );
-            }
+            with_cfg_flag!(
+                $engine,
+                impl Ops<$engine, $scalar> {
+                    with_feature_flag!(
+                        $engine,
+                        #[inline]
+                        pub unsafe fn $name($($arg: $arg_ty),*) $( -> $ret_ty )? {
+                            $( $body )*
+                        }
+                    );
+                }
+            );
         )*
     }
 }
@@ -90,15 +129,18 @@ macro_rules! impl_imm8_op {
         )*
     }) => {
         $(
-            impl Ops<$engine, $scalar> {
-                with_feature_flag!(
-                    $engine,
-                    #[inline]
-                    pub unsafe fn $name < const $imm8: $imm8ty > ($($arg: $arg_ty),*) $( -> $ret_ty )? {
-                        $( $body )*
-                    }
-                );
-            }
+            with_cfg_flag!(
+                $engine,
+                impl Ops<$engine, $scalar> {
+                    with_feature_flag!(
+                        $engine,
+                        #[inline]
+                        pub unsafe fn $name < const $imm8: $imm8ty > ($($arg: $arg_ty),*) $( -> $ret_ty )? {
+                            $( $body )*
+                        }
+                    );
+                }
+            );
         )*
     }
 }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,19 +1,20 @@
 #![allow(dead_code)]
 
+#[cfg(target_arch = "aarch64")]
+use crate::engines::neon::Neon;
 use crate::engines::scalar::Scalar;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 use crate::engines::{avx2::Avx2, sse2::Sse2, sse41::Sse41};
-#[cfg(target_arch = "aarch64")]
-use crate::engines::{neon::Neon};
+
 use crate::libm_ext::FloatExt;
 use core::marker::PhantomData;
 
+#[cfg(target_arch = "aarch64")]
+use core::arch::aarch64::*;
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
-#[cfg(target_arch = "aarch64")]
-use core::arch::aarch64::*;
 
 mod i8;
 pub use self::i8::*;

--- a/src/tests/lib/constify.rs
+++ b/src/tests/lib/constify.rs
@@ -7,7 +7,6 @@ macro_rules! test_constify_imm8 {
         #[allow(clippy::suspicious_op_assign_impl)]
         #[allow(clippy::suspicious_arithmetic_impl)]
         match ($imm8) & 0b1111_1111 {
-            0 => $expand!(0),
             1 => $expand!(1),
             2 => $expand!(2),
             3 => $expand!(3),
@@ -263,6 +262,158 @@ macro_rules! test_constify_imm8 {
             253 => $expand!(253),
             254 => $expand!(254),
             _ => $expand!(255),
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! test_constify_imm8_for_bitshift {
+    (i64, $imm8:expr, $expand:ident) => {
+        #[allow(overflowing_literals)]
+        #[allow(clippy::suspicious_op_assign_impl)]
+        #[allow(clippy::suspicious_arithmetic_impl)]
+        match ($imm8) & 0b1111_1111 {
+            1 => $expand!(1),
+            2 => $expand!(2),
+            3 => $expand!(3),
+            4 => $expand!(4),
+            5 => $expand!(5),
+            6 => $expand!(6),
+            7 => $expand!(7),
+            8 => $expand!(8),
+            9 => $expand!(9),
+            10 => $expand!(10),
+            11 => $expand!(11),
+            12 => $expand!(12),
+            13 => $expand!(13),
+            14 => $expand!(14),
+            15 => $expand!(15),
+            16 => $expand!(16),
+            17 => $expand!(17),
+            18 => $expand!(18),
+            19 => $expand!(19),
+            20 => $expand!(20),
+            21 => $expand!(21),
+            22 => $expand!(22),
+            23 => $expand!(23),
+            24 => $expand!(24),
+            25 => $expand!(25),
+            26 => $expand!(26),
+            27 => $expand!(27),
+            28 => $expand!(28),
+            29 => $expand!(29),
+            30 => $expand!(30),
+            31 => $expand!(31),
+            32 => $expand!(32),
+            33 => $expand!(33),
+            34 => $expand!(34),
+            35 => $expand!(35),
+            36 => $expand!(36),
+            37 => $expand!(37),
+            38 => $expand!(38),
+            39 => $expand!(39),
+            40 => $expand!(40),
+            41 => $expand!(41),
+            42 => $expand!(42),
+            43 => $expand!(43),
+            44 => $expand!(44),
+            45 => $expand!(45),
+            46 => $expand!(46),
+            47 => $expand!(47),
+            48 => $expand!(48),
+            49 => $expand!(49),
+            50 => $expand!(50),
+            51 => $expand!(51),
+            52 => $expand!(52),
+            53 => $expand!(53),
+            54 => $expand!(54),
+            55 => $expand!(55),
+            56 => $expand!(56),
+            57 => $expand!(57),
+            58 => $expand!(58),
+            59 => $expand!(59),
+            60 => $expand!(60),
+            61 => $expand!(61),
+            62 => $expand!(62),
+            63 => $expand!(63),
+            _ => $expand!(63),
+        }
+    };
+    (i32, $imm8:expr, $expand:ident) => {
+        #[allow(overflowing_literals)]
+        #[allow(clippy::suspicious_op_assign_impl)]
+        #[allow(clippy::suspicious_arithmetic_impl)]
+        match ($imm8) & 0b1111_1111 {
+            1 => $expand!(1),
+            2 => $expand!(2),
+            3 => $expand!(3),
+            4 => $expand!(4),
+            5 => $expand!(5),
+            6 => $expand!(6),
+            7 => $expand!(7),
+            8 => $expand!(8),
+            9 => $expand!(9),
+            10 => $expand!(10),
+            11 => $expand!(11),
+            12 => $expand!(12),
+            13 => $expand!(13),
+            14 => $expand!(14),
+            15 => $expand!(15),
+            16 => $expand!(16),
+            17 => $expand!(17),
+            18 => $expand!(18),
+            19 => $expand!(19),
+            20 => $expand!(20),
+            21 => $expand!(21),
+            22 => $expand!(22),
+            23 => $expand!(23),
+            24 => $expand!(24),
+            25 => $expand!(25),
+            26 => $expand!(26),
+            27 => $expand!(27),
+            28 => $expand!(28),
+            29 => $expand!(29),
+            30 => $expand!(30),
+            31 => $expand!(31),
+            _ => $expand!(31),
+        }
+    };
+    (i16, $imm8:expr, $expand:ident) => {
+        #[allow(overflowing_literals)]
+        #[allow(clippy::suspicious_op_assign_impl)]
+        #[allow(clippy::suspicious_arithmetic_impl)]
+        match ($imm8) & 0b1111_1111 {
+            1 => $expand!(1),
+            2 => $expand!(2),
+            3 => $expand!(3),
+            4 => $expand!(4),
+            5 => $expand!(5),
+            6 => $expand!(6),
+            7 => $expand!(7),
+            8 => $expand!(8),
+            9 => $expand!(9),
+            10 => $expand!(10),
+            11 => $expand!(11),
+            12 => $expand!(12),
+            13 => $expand!(13),
+            14 => $expand!(14),
+            15 => $expand!(15),
+            _ => $expand!(15),
+        }
+    };
+    (i8, $imm8:expr, $expand:ident) => {
+        #[allow(overflowing_literals)]
+        #[allow(clippy::suspicious_op_assign_impl)]
+        #[allow(clippy::suspicious_arithmetic_impl)]
+        match ($imm8) & 0b1111_1111 {
+            1 => $expand!(1),
+            2 => $expand!(2),
+            3 => $expand!(3),
+            4 => $expand!(4),
+            5 => $expand!(5),
+            6 => $expand!(6),
+            7 => $expand!(7),
+            _ => $expand!(7),
         }
     };
 }

--- a/src/tests/run.rs
+++ b/src/tests/run.rs
@@ -1,4 +1,4 @@
-use crate::{elementwise_eq_tester};
+use crate::elementwise_eq_tester;
 
 use super::*;
 

--- a/src/tests/run.rs
+++ b/src/tests/run.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports)]
+
 use crate::elementwise_eq_tester;
 
 use super::*;

--- a/src/tests/run.rs
+++ b/src/tests/run.rs
@@ -1,8 +1,13 @@
-use crate::{elementwise_eq_tester, test_constify_imm8};
+use crate::{elementwise_eq_tester};
 
 use super::*;
 
-use crate::engines::{avx2::*, scalar::*, sse2::*, sse41::*};
+#[cfg(target_arch = "aarch64")]
+use crate::engines::neon::Neon;
+use crate::engines::scalar::*;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+use crate::engines::{avx2::*, sse2::*, sse41::*};
+
 use crate::*;
 
 elementwise_eq_tester_impl!(SimdBaseOps, add, two_arg, EqPrecision::exact());
@@ -57,7 +62,7 @@ elementwise_eq_tester_impl!(SimdFloat, neg_mul_add, three_arg, EqPrecision::almo
 elementwise_eq_tester_impl!(SimdFloat, neg_mul_sub, three_arg, EqPrecision::almost(5));
 
 elementwise_eq_tester_impl!(SimdFloat, sqrt, one_arg, EqPrecision::almost(7));
-elementwise_eq_tester_impl!(SimdFloat, rsqrt, one_arg, EqPrecision::almost(3)); // Has very low precision
+elementwise_eq_tester_impl!(SimdFloat, rsqrt, one_arg, EqPrecision::almost(2)); // Has very low precision
 
 bitshift_eq_tester_impl!(dyn shl);
 bitshift_eq_tester_impl!(dyn shr);


### PR DESCRIPTION
Added:
- Mappings for Arm Neon intrinsics (aarch64 architecture)
- Target flags for switching between x86 and aarch64 around the codebase
- Full testing for Neon instructions
- Refactored GitHub Actions to support testing all platforms