### PR TITLE
Small improvements for the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,25 +50,21 @@ performance as long as you don't run into some of the slower fallback functions.
 # Example
 
 ```rust
-use simdeez::*;
+    use simdeez::prelude::*;
+
+    use simdeez::avx2::*;
     use simdeez::scalar::*;
     use simdeez::sse2::*;
     use simdeez::sse41::*;
-    use simdeez::avx::*;
-    use simdeez::avx2::*;
+
     // If you want your SIMD function to use use runtime feature detection to call
     // the fastest available version, use the simd_runtime_generate macro:
     simd_runtime_generate!(
-    fn distance(
-        x1: &[f32],
-        y1: &[f32],
-        x2: &[f32],
-        y2: &[f32]) -> Vec<f32> {
-
+    fn distance(x1: &[f32], y1: &[f32], x2: &[f32], y2: &[f32]) -> Vec<f32> {
         let mut result: Vec<f32> = Vec::with_capacity(x1.len());
         result.set_len(x1.len()); // for efficiency
 
-        /// Set each slice to the same length for iteration efficiency
+        // Set each slice to the same length for iteration efficiency
         let mut x1 = &x1[..x1.len()];
         let mut y1 = &y1[..x1.len()];
         let mut x2 = &x2[..x1.len()];
@@ -79,34 +75,31 @@ use simdeez::*;
         // so that it will work with any size vector.
         // the width of a vector type is provided as a constant
         // so the compiler is free to optimize it more.
-        // S::VF32_WIDTH is a constant, 4 when using SSE, 8 when using AVX2, etc
-        while x1.len() >= S::VF32_WIDTH {
+        // S::Simd::Vf32::WIDTH is a constant, 4 when using SSE, 8 when using AVX2, etc
+        while x1.len() >= S::Vf32::WIDTH {
             //load data from your vec into an SIMD value
-            let xv1 = S::loadu_ps(&x1[0]);
-            let yv1 = S::loadu_ps(&y1[0]);
-            let xv2 = S::loadu_ps(&x2[0]);
-            let yv2 = S::loadu_ps(&y2[0]);
+            let xv1 = S::Vf32::load_from_slice(x1);
+            let yv1 = S::Vf32::load_from_slice(y1);
+            let xv2 = S::Vf32::load_from_slice(x2);
+            let yv2 = S::Vf32::load_from_slice(y2);
 
-            // Use the usual intrinsic syntax if you prefer
-            let mut xdiff = S::sub_ps(xv1, xv2);
-            // Or use operater overloading if you like
+            let mut xdiff = xv1 - xv2;
             let mut ydiff = yv1 - yv2;
             xdiff *= xdiff;
             ydiff *= ydiff;
-            let distance = S::sqrt_ps(xdiff + ydiff);
+            let distance = (xdiff + ydiff).sqrt();
             // Store the SIMD value into the result vec
-            S::storeu_ps(&mut res[0], distance);
-
+            distance.copy_to_slice(&mut res);
             // Move each slice to the next position
-            x1 = &x1[S::VF32_WIDTH..];
-            y1 = &y1[S::VF32_WIDTH..];
-            x2 = &x2[S::VF32_WIDTH..];
-            y2 = &y2[S::VF32_WIDTH..];
-            res = &mut res[S::VF32_WIDTH..];
+            x1 = &x1[S::Vf32::WIDTH..];
+            y1 = &y1[S::Vf32::WIDTH..];
+            x2 = &x2[S::Vf32::WIDTH..];
+            y2 = &y2[S::Vf32::WIDTH..];
+            res = &mut res[S::Vf32::WIDTH..];
         }
 
         // (Optional) Compute the remaining elements. Not necessary if you are sure the length
-        // of your data is always a multiple of the maximum S::VF32_WIDTH you compile for (4 for SSE, 8 for AVX2, etc).
+        // of your data is always a multiple of the maximum S::Simd::Vf32::WIDTH you compile for (4 for SSE, 8 for AVX2, etc).
         // This can be asserted by putting `assert_eq!(x1.len(), 0);` here
         for i in 0..x1.len() {
             let mut xdiff = x1[i] - x2[i];
@@ -121,6 +114,7 @@ use simdeez::*;
     });
 fn main() {
 }
+
 ```
 This will generate 5 functions for you:
 * `distance<S:Simd>` the generic version of your function

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,20 +50,16 @@
 //!
 //! ```rust
 //!     use simdeez::prelude::*;
-//!     use simdeez::*;
+//!
+//!     use simdeez::avx2::*;
 //!     use simdeez::scalar::*;
 //!     use simdeez::sse2::*;
 //!     use simdeez::sse41::*;
-//!     use simdeez::avx2::*;
+//!
 //!     // If you want your SIMD function to use use runtime feature detection to call
 //!     // the fastest available version, use the simd_runtime_generate macro:
 //!     simd_runtime_generate!(
-//!     fn distance(
-//!         x1: &[f32],
-//!         y1: &[f32],
-//!         x2: &[f32],
-//!         y2: &[f32]) -> Vec<f32> {
-//!
+//!     fn distance(x1: &[f32], y1: &[f32], x2: &[f32], y2: &[f32]) -> Vec<f32> {
 //!         let mut result: Vec<f32> = Vec::with_capacity(x1.len());
 //!         result.set_len(x1.len()); // for efficiency
 //!
@@ -78,23 +74,21 @@
 //!         // so that it will work with any size vector.
 //!         // the width of a vector type is provided as a constant
 //!         // so the compiler is free to optimize it more.
-//!         // S::Vf32::WIDTH is a constant, 4 when using SSE, 8 when using AVX2, etc
+//!         // S::Simd::Vf32::WIDTH is a constant, 4 when using SSE, 8 when using AVX2, etc
 //!         while x1.len() >= S::Vf32::WIDTH {
 //!             //load data from your vec into an SIMD value
-//!             let xv1 = S::loadu_ps(&x1[0]);
-//!             let yv1 = S::loadu_ps(&y1[0]);
-//!             let xv2 = S::loadu_ps(&x2[0]);
-//!             let yv2 = S::loadu_ps(&y2[0]);
+//!             let xv1 = S::Vf32::load_from_slice(x1);
+//!             let yv1 = S::Vf32::load_from_slice(y1);
+//!             let xv2 = S::Vf32::load_from_slice(x2);
+//!             let yv2 = S::Vf32::load_from_slice(y2);
 //!
-//!             // Use the usual intrinsic syntax if you prefer
-//!             let mut xdiff = S::sub_ps(xv1, xv2);
-//!             // Or use operater overloading if you like
+//!             let mut xdiff = xv1 - xv2;
 //!             let mut ydiff = yv1 - yv2;
 //!             xdiff *= xdiff;
 //!             ydiff *= ydiff;
-//!             let distance = S::sqrt_ps(xdiff + ydiff);
+//!             let distance = (xdiff + ydiff).sqrt();
 //!             // Store the SIMD value into the result vec
-//!             S::storeu_ps(&mut res[0], distance);
+//!             distance.copy_to_slice(&mut res);
 //!
 //!             // Move each slice to the next position
 //!             x1 = &x1[S::Vf32::WIDTH..];
@@ -105,7 +99,7 @@
 //!         }
 //!
 //!         // (Optional) Compute the remaining elements. Not necessary if you are sure the length
-//!         // of your data is always a multiple of the maximum S::Vf32::WIDTH you compile for (4 for SSE, 8 for AVX2, etc).
+//!         // of your data is always a multiple of the maximum S::Simd::Vf32::WIDTH you compile for (4 for SSE, 8 for AVX2, etc).
 //!         // This can be asserted by putting `assert_eq!(x1.len(), 0);` here
 //!         for i in 0..x1.len() {
 //!             let mut xdiff = x1[i] - x2[i];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@
 //! # Example
 //!
 //! ```rust
+//!     use simdeez::prelude::*;
 //!     use simdeez::*;
 //!     use simdeez::scalar::*;
 //!     use simdeez::sse2::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,8 +78,8 @@
 //!         // so that it will work with any size vector.
 //!         // the width of a vector type is provided as a constant
 //!         // so the compiler is free to optimize it more.
-//!         // S::VF32_WIDTH is a constant, 4 when using SSE, 8 when using AVX2, etc
-//!         while x1.len() >= S::VF32_WIDTH {
+//!         // S::Vf32::WIDTH is a constant, 4 when using SSE, 8 when using AVX2, etc
+//!         while x1.len() >= S::Vf32::WIDTH {
 //!             //load data from your vec into an SIMD value
 //!             let xv1 = S::loadu_ps(&x1[0]);
 //!             let yv1 = S::loadu_ps(&y1[0]);
@@ -97,15 +97,15 @@
 //!             S::storeu_ps(&mut res[0], distance);
 //!
 //!             // Move each slice to the next position
-//!             x1 = &x1[S::VF32_WIDTH..];
-//!             y1 = &y1[S::VF32_WIDTH..];
-//!             x2 = &x2[S::VF32_WIDTH..];
-//!             y2 = &y2[S::VF32_WIDTH..];
-//!             res = &mut res[S::VF32_WIDTH..];
+//!             x1 = &x1[S::Vf32::WIDTH..];
+//!             y1 = &y1[S::Vf32::WIDTH..];
+//!             x2 = &x2[S::Vf32::WIDTH..];
+//!             y2 = &y2[S::Vf32::WIDTH..];
+//!             res = &mut res[S::Vf32::WIDTH..];
 //!         }
 //!
 //!         // (Optional) Compute the remaining elements. Not necessary if you are sure the length
-//!         // of your data is always a multiple of the maximum S::VF32_WIDTH you compile for (4 for SSE, 8 for AVX2, etc).
+//!         // of your data is always a multiple of the maximum S::Vf32::WIDTH you compile for (4 for SSE, 8 for AVX2, etc).
 //!         // This can be asserted by putting `assert_eq!(x1.len(), 0);` here
 //!         for i in 0..x1.len() {
 //!             let mut xdiff = x1[i] - x2[i];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 //!         let mut result: Vec<f32> = Vec::with_capacity(x1.len());
 //!         result.set_len(x1.len()); // for efficiency
 //!
-//!         /// Set each slice to the same length for iteration efficiency
+//!         // Set each slice to the same length for iteration efficiency
 //!         let mut x1 = &x1[..x1.len()];
 //!         let mut y1 = &y1[..x1.len()];
 //!         let mut x2 = &x2[..x1.len()];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -943,7 +943,7 @@ pub trait Simd: 'static + Sync + Send {
         SimdBaseIo::load_from_ptr_unaligned(a)
     }
 
-    /// Note, SSE2 and SSE4 will load when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will load when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability
     /// ensure that the high bit is set.
     #[deprecated(
@@ -952,7 +952,7 @@ pub trait Simd: 'static + Sync + Send {
     unsafe fn maskload_epi32(_mem_addr: &i32, _mask: Self::Vi32) -> Self::Vi32 {
         panic!("Deprecated")
     }
-    /// Note, SSE2 and SSE4 will load when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will load when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability
     /// ensure that the high bit is set.
     #[deprecated(
@@ -961,7 +961,7 @@ pub trait Simd: 'static + Sync + Send {
     unsafe fn maskload_epi64(_mem_addr: &i64, _mask: Self::Vi64) -> Self::Vi64 {
         panic!("Deprecated")
     }
-    /// Note, SSE2 and SSE4 will load when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will load when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability
     /// ensure that the high bit is set.
     #[deprecated(
@@ -970,7 +970,7 @@ pub trait Simd: 'static + Sync + Send {
     unsafe fn maskload_ps(_mem_addr: &f32, _mask: Self::Vi32) -> Self::Vf32 {
         panic!("Deprecated")
     }
-    /// Note, SSE2 and SSE4 will load when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will load when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability
     /// ensure that the high bit is set.
     #[deprecated(
@@ -1029,7 +1029,7 @@ pub trait Simd: 'static + Sync + Send {
         SimdBaseIo::copy_to_ptr_unaligned(a, mem_addr)
     }
 
-    /// Note, SSE2 and SSE4 will store when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will store when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability ensure the
     /// high bit is set.
     #[deprecated(
@@ -1040,7 +1040,7 @@ pub trait Simd: 'static + Sync + Send {
             *mem_addr = a[0];
         }
     }
-    /// Note, SSE2 and SSE4 will store when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will store when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability ensure the
     /// high bit is set.
     #[deprecated(
@@ -1051,7 +1051,7 @@ pub trait Simd: 'static + Sync + Send {
             *mem_addr = a[0];
         }
     }
-    /// Note, SSE2 and SSE4 will store when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will store when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability ensure the
     /// high bit is set.
     #[deprecated(
@@ -1062,7 +1062,7 @@ pub trait Simd: 'static + Sync + Send {
             *mem_addr = a[0];
         }
     }
-    /// Note, SSE2 and SSE4 will store when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will store when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability ensure the
     /// high bit is set.
     #[deprecated(


### PR DESCRIPTION
I started working on transitioning (https://github.com/verpeteren/rust-simd-noise/pull/50/files#top) from `rust-simd-noise` on top of the 64 bit changes (https://github.com/verpeteren/rust-simd-noise/pull/51), but got kindof stuck because it seems that the `Avx2`, `Sse2`, `Sse41` engines are not exported, only `Scalar` is available.

Upon further investigation, it seems that the examples were outdated and showed the same issue.

Please advice on how I can improve/continue with this.

```bash
cargo test
```
gives
```text
   Compiling simdeez v2.0.0-dev3 (/data/Development/other/simdeez)
error[E0432]: unresolved import `simdeez::avx2`
 --> src/main.rs:3:14
  |
3 | use simdeez::avx2::*;
  |              ^^^^ could not find `avx2` in `simdeez`

error[E0432]: unresolved import `simdeez::sse2`
 --> src/main.rs:5:14
  |
5 | use simdeez::sse2::*;
  |              ^^^^ could not find `sse2` in `simdeez`

error[E0432]: unresolved import `simdeez::sse41`
 --> src/main.rs:6:14
  |
6 | use simdeez::sse41::*;
  |              ^^^^^ could not find `sse41` in `simdeez`

warning: unused import: `simdeez::scalar::*`
 --> src/main.rs:4:5
  |
4 | use simdeez::scalar::*;
  |     ^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

For more information about this error, try `rustc --explain E0432`.
warning: `simdeez` (bin "simdeez" test) generated 1 warning
error: could not compile `simdeez` (bin "simdeez" test) due to 3 previous errors; 1 warning emitted
warning: build failed, waiting for other jobs to finish...
```


This PR is broken down into small atomic commits that should be easy to review 