### PR TITLE
Bump Rust edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["SIMD", "avx2", "sse", "performance", "no_std"]
 repository = "https://github.com/jackmott/simdeez"
 categories = ["hardware-support", "science", "game-engines"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 doctest = false


### PR DESCRIPTION
Bump Rust edition to 2021, there should be no harm in it. No code change was required, although I didn't check if there's something which could be refactored to take advantage of the new edition.