### PR TITLE
Use vmsfq intrinsic for NEON neg_mul_add

### DIFF
--- a/src/ops/f32.rs
+++ b/src/ops/f32.rs
@@ -135,7 +135,7 @@ impl_op! {
             c - a * b
         }
         for Neon(a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
-            vfmaq_f32(c, vnegq_f32(a), b)
+            vfmsq_f32(c, a, b)
         }
     }
 }

--- a/src/ops/f64.rs
+++ b/src/ops/f64.rs
@@ -135,7 +135,7 @@ impl_op! {
             c - a * b
         }
         for Neon(a: float64x2_t, b: float64x2_t, c: float64x2_t) -> float64x2_t {
-            vfmaq_f64(c, vnegq_f64(a), b)
+            vfmsq_f64(c, a, b)
         }
     }
 }


### PR DESCRIPTION
While AVX2's `_mm_fmsub_*` intrinsics subtract the last operand from the product, ARM's `vmsfq_*` intrinsics subtract the product from the last operand. This means we can use them to implement a one-instruction `neg_mul_add`.