### PR TITLE
chore: escape brackets in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -942,7 +942,7 @@ pub trait Simd: 'static + Sync + Send {
         SimdBaseIo::load_from_ptr_unaligned(a)
     }
 
-    /// Note, SSE2 and SSE4 will load when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will load when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability
     /// ensure that the high bit is set.
     #[deprecated(
@@ -951,7 +951,7 @@ pub trait Simd: 'static + Sync + Send {
     unsafe fn maskload_epi32(_mem_addr: &i32, _mask: Self::Vi32) -> Self::Vi32 {
         panic!("Deprecated")
     }
-    /// Note, SSE2 and SSE4 will load when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will load when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability
     /// ensure that the high bit is set.
     #[deprecated(
@@ -960,7 +960,7 @@ pub trait Simd: 'static + Sync + Send {
     unsafe fn maskload_epi64(_mem_addr: &i64, _mask: Self::Vi64) -> Self::Vi64 {
         panic!("Deprecated")
     }
-    /// Note, SSE2 and SSE4 will load when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will load when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability
     /// ensure that the high bit is set.
     #[deprecated(
@@ -969,7 +969,7 @@ pub trait Simd: 'static + Sync + Send {
     unsafe fn maskload_ps(_mem_addr: &f32, _mask: Self::Vi32) -> Self::Vf32 {
         panic!("Deprecated")
     }
-    /// Note, SSE2 and SSE4 will load when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will load when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability
     /// ensure that the high bit is set.
     #[deprecated(
@@ -1028,7 +1028,7 @@ pub trait Simd: 'static + Sync + Send {
         SimdBaseIo::copy_to_ptr_unaligned(a, mem_addr)
     }
 
-    /// Note, SSE2 and SSE4 will store when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will store when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability ensure the
     /// high bit is set.
     #[deprecated(
@@ -1039,7 +1039,7 @@ pub trait Simd: 'static + Sync + Send {
             *mem_addr = a[0];
         }
     }
-    /// Note, SSE2 and SSE4 will store when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will store when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability ensure the
     /// high bit is set.
     #[deprecated(
@@ -1050,7 +1050,7 @@ pub trait Simd: 'static + Sync + Send {
             *mem_addr = a[0];
         }
     }
-    /// Note, SSE2 and SSE4 will store when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will store when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability ensure the
     /// high bit is set.
     #[deprecated(
@@ -1061,7 +1061,7 @@ pub trait Simd: 'static + Sync + Send {
             *mem_addr = a[0];
         }
     }
-    /// Note, SSE2 and SSE4 will store when mask[i] is nonzero, where AVX2
+    /// Note, SSE2 and SSE4 will store when mask\[i\] is nonzero, where AVX2
     /// will store only when the high bit is set. To ensure portability ensure the
     /// high bit is set.
     #[deprecated(


### PR DESCRIPTION
Cargo doc was raising a warning like this:

```
warning: unresolved link to `i`
    --> src/lib.rs:1053:50
     |
1053 |     /// Note, SSE2 and SSE4 will store when mask[i] is nonzero, where AVX2
     |                                                  ^ no item named `i` in scope
     |
     = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
     = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
```