### PR TITLE
chore: apply cargo fix

### DIFF
--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -17,28 +17,20 @@ use core::arch::x86::*;
 use core::arch::x86_64::*;
 
 mod i8;
-pub use self::i8::*;
 
 mod i16;
-pub use self::i16::*;
 
 mod i32;
-pub use self::i32::*;
 
 mod i64;
-pub use self::i64::*;
 
 mod f32;
-pub use self::f32::*;
 
 mod f64;
-pub use self::f64::*;
 
 mod bit;
-pub use self::bit::*;
 
 mod casts;
-pub use self::casts::*;
 
 #[allow(non_camel_case_types)]
 pub struct binary;


### PR DESCRIPTION
running cargo tests gave a warning:

```
warning: `simdeez` (lib) generated 10 warnings (run `cargo fix --lib -p simdeez` to apply 8 suggestions)
```

This PR is the outcome of applying `cargo fix --lib -p simdeez`