### PR TITLE
Enable FMA feature for AVX2

### DIFF
--- a/src/engines/avx2/simd.rs
+++ b/src/engines/avx2/simd.rs
@@ -15,7 +15,7 @@ impl Simd for Avx2 {
     #[inline]
     fn invoke<R>(f: impl FnOnce() -> R) -> R {
         #[inline]
-        #[target_feature(enable = "avx2")]
+        #[target_feature(enable = "avx2", enable = "fma")]
         unsafe fn inner<R>(f: impl FnOnce() -> R) -> R {
             f()
         }

--- a/src/invoking.rs
+++ b/src/invoking.rs
@@ -173,7 +173,7 @@ pub fn __run_simd_runtime_decide<S: __SimdRunner<A, R>, A, R>(args: A) -> R {
 
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     {
-        if is_x86_feature_detected!("avx2") {
+        if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
             return unsafe { S::run::<engines::avx2::Avx2>(args) };
         }
 
@@ -212,7 +212,7 @@ pub fn __run_simd_compiletime_select<S: __SimdRunner<A, R>, A, R>(args: A) -> R 
 
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     {
-        #[cfg(target_feature = "avx2")]
+        #[cfg(all(target_feature = "avx2", target_feature = "fma"))]
         return unsafe { S::run::<engines::avx2::Avx2>(args) };
 
         #[cfg(target_feature = "sse4.1")]

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -44,7 +44,7 @@ pub struct Ops<T, T2>(PhantomData<(T, T2)>);
 macro_rules! with_feature_flag {
     (Avx2, $($r:tt)+) => {
         #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-        #[target_feature(enable = "avx2")]
+        #[target_feature(enable = "avx2", enable = "fma")]
         $($r)+
     };
     (Sse2, $($r:tt)+) => {

--- a/src/tests/lib/tester.rs
+++ b/src/tests/lib/tester.rs
@@ -191,7 +191,7 @@ macro_rules! horizontal_add_tester {
 #[macro_export]
 macro_rules! with_feature_flag {
     (Avx2, $($r:tt)+) => {
-        #[cfg(target_feature = "avx2")]
+        #[cfg(all(target_feature = "avx2", target_feature = "fma"))]
         $($r)+
     };
     (Sse2, $($r:tt)+) => {


### PR DESCRIPTION
Resolves #77. Allows the multiply-add functions to work at full speed.