### PR TITLE
Inline Index and IndexMut implementations

### DIFF
--- a/src/overloads.rs
+++ b/src/overloads.rs
@@ -244,12 +244,14 @@ macro_rules! impl_simd_base_overloads {
         impl Index<usize> for $s {
             type Output = <Self as SimdConsts>::Scalar;
 
+            #[inline(always)]
             fn index(&self, index: usize) -> &Self::Output {
                 unsafe { &(*self.transmute_into_array_ref())[index] }
             }
         }
 
         impl IndexMut<usize> for $s {
+            #[inline(always)]
             fn index_mut(&mut self, index: usize) -> &mut Self::Output {
                 unsafe { &mut (*self.transmute_into_array_mut())[index] }
             }


### PR DESCRIPTION
I ran into this when optimizing simdnoise. With gather ops no longer being a thing, I reimplemented them as standard loops. This led to a 20-30% slowdown in my application (which spends around half its time in simdnoise, so simdnoise itself is about 40-60% slower).

I thought the software gather ops were just inherently slower, but the actual problem is [this line](https://github.com/verpeteren/rust-simd-noise/blob/428ae7a6a071f47d9629ab6aab5ed896a51e5b74/src/noise/ops.rs#L10), with the innocuous-looking `indices[i]` access. `i` ranges from 0 to `WIDTH`, so the compiler *should* be able to easily remove the bounds check, but it couldn't, because the indexing operations couldn't be inlined.

With that fixed, simdnoise should now be as fast as it used to be before updating to simdeez 2.